### PR TITLE
Twist qc

### DIFF
--- a/cg_lims/EPPs/udf/calculate/base.py
+++ b/cg_lims/EPPs/udf/calculate/base.py
@@ -6,6 +6,7 @@ import click
 from cg_lims.EPPs.udf.calculate.twist_pool import twist_pool
 from cg_lims.EPPs.udf.calculate.twist_aliquot_amount import twist_aliquot_amount
 from cg_lims.EPPs.udf.calculate.twist_aliquot_volume import twist_aliquot_volume
+from cg_lims.EPPs.udf.calculate.twist_qc_amount import twist_qc_amount
 
 
 @click.group(invoke_without_command=True)
@@ -18,5 +19,6 @@ def calculate(ctx):
 calculate.add_command(twist_pool)
 calculate.add_command(twist_aliquot_amount)
 calculate.add_command(twist_aliquot_volume)
+calculate.add_command(twist_qc_amount)
 
 

--- a/cg_lims/EPPs/udf/calculate/twist_qc_amount.py
+++ b/cg_lims/EPPs/udf/calculate/twist_qc_amount.py
@@ -18,10 +18,10 @@ def get_qc(source: str, conc: float, amount: float) -> str:
     qc = "FAILED"
 
     if source == "cfDNA":
-        if amount >= 10 and conc <= 250 and amount >= conc >= amount / 50.0:
+        if amount >= 10 and conc <= 250 and conc >= 0.2:
             qc = "PASSED"
     else:
-        if amount >= 300 and conc <= 250:
+        if amount >= 300 and conc <= 250 and conc >= 8.33:
             qc = "PASSED"
 
     return qc

--- a/cg_lims/EPPs/udf/calculate/twist_qc_amount.py
+++ b/cg_lims/EPPs/udf/calculate/twist_qc_amount.py
@@ -50,9 +50,9 @@ def calculate_amount_and_set_qc(artifacts: List[Artifact]) -> None:
         artifact.put()
 
     if missing_udfs_count:
-        raise MissingUDFsError(f"Udf missing for {missing_udfs_count} samples")
+        raise MissingUDFsError(f"Udf missing for {missing_udfs_count} sample(s).")
     if qc_fail_count:
-        raise FailingQCError(f"QC failed for {qc_fail_count} samples")
+        raise FailingQCError(f"Amounts have been calculated and qc flags set for all samples. QC failed for {qc_fail_count} sample(s).")
 
 
 @click.command()

--- a/cg_lims/EPPs/udf/calculate/twist_qc_amount.py
+++ b/cg_lims/EPPs/udf/calculate/twist_qc_amount.py
@@ -18,10 +18,10 @@ def get_qc(source: str, conc: float, amount: float) -> str:
     qc = "FAILED"
 
     if source == "cfDNA":
-        if amount >= 10 and conc <= 250 and amount / 1.0 >= conc >= amount / 50.0:
+        if amount >= 10 and conc <= 250 and amount >= conc >= amount / 50.0:
             qc = "PASSED"
     else:
-        if amount >= 300 and conc <= 250 and amount / 1.0 >= conc >= amount / 30.0:
+        if amount >= 300 and conc <= 250 and amount >= conc >= amount / 30.0:
             qc = "PASSED"
 
     return qc

--- a/cg_lims/EPPs/udf/calculate/twist_qc_amount.py
+++ b/cg_lims/EPPs/udf/calculate/twist_qc_amount.py
@@ -21,7 +21,7 @@ def get_qc(source: str, conc: float, amount: float) -> str:
         if amount >= 10 and conc <= 250 and amount >= conc >= amount / 50.0:
             qc = "PASSED"
     else:
-        if amount >= 300 and conc <= 250 and amount >= conc >= amount / 30.0:
+        if amount >= 300 and conc <= 250:
             qc = "PASSED"
 
     return qc
@@ -46,7 +46,8 @@ def calculate_amount_and_set_qc(artifacts: List[Artifact]) -> None:
         qc = get_qc(source, conc, amount)
         if qc == "FAILED":
             qc_fail_count +=1
-        artifact.qc_flag = get_qc(source, conc, amount)
+            LOG.info(f"Sample {sample.id} failed qc. Source: {source} Amount: {amount} Concentration: {conc}")
+        artifact.qc_flag = qc
         artifact.put()
 
     if missing_udfs_count:

--- a/cg_lims/EPPs/udf/calculate/twist_qc_amount.py
+++ b/cg_lims/EPPs/udf/calculate/twist_qc_amount.py
@@ -13,7 +13,7 @@ LOG = logging.getLogger(__name__)
 
 
 def get_qc(source: str, conc: float, amount: float) -> str:
-    """"""
+    """QC-criteria depends on sample source, total amount and sample concentration. See AMS doc 1117, 1993 and 2125."""
 
     qc = "FAILED"
 

--- a/cg_lims/EPPs/udf/calculate/twist_qc_amount.py
+++ b/cg_lims/EPPs/udf/calculate/twist_qc_amount.py
@@ -1,0 +1,71 @@
+
+from genologics.entities import Artifact
+
+import logging
+import sys
+import click
+from typing import List
+
+from cg_lims.exceptions import LimsError, MissingUDFsError
+from cg_lims.get.artifacts import get_qc_messuements
+from cg_lims.get.samples import get_artifact_sample
+
+LOG = logging.getLogger(__name__)
+
+
+def get_qc(source: str, conc: float, amount: float)-> str:
+    """"""
+
+    qc='FAILED'
+
+    if source=='cfDNA':
+        if amount >= 10 and conc <= 250 and amount/1 >= conc >= amount/50:
+            qc = 'PASSED'
+    else:
+        if amount >= 300 and conc <= 250 and amount/1 >= conc >= amount/30:
+            qc = 'PASSED'
+
+    return qc
+
+
+
+def calculate_amount_and_set_qc(artifacts: List[Artifact])-> None:
+    """Calculate amount and set qc for twist samples"""
+    missing_udfs = 0
+    for artifact in artifacts:
+        sample = get_artifact_sample(artifact)
+        source = sample.udf.get('Source')
+        vol = artifact.udf.get('Volume (ul)')
+        conc = artifact.udf.get('Concentration')
+        if None in [source, conc, vol]:
+            missing_udfs += 1
+            continue
+
+        amount = conc*vol
+        artifact.udf['Amount (ng)'] = amount
+        artifact.qc_flag = get_qc(source, conc, amount)
+        artifact.put()
+
+    if missing_udfs:
+        raise MissingUDFsError(f"Udf missing for {missing_udfs} samples")
+
+
+@click.command()
+@click.pass_context
+def twist_qc_amount(ctx):
+    """Calculates amount of samples for qc validation."""
+
+    LOG.info(f"Running {ctx.command_path} with params: {ctx.params}")
+
+    process = ctx.obj["process"]
+    lims = ctx.obj["lims"]
+
+    try:
+        artifacts = get_qc_messuements(lims=lims, process=process)
+        calculate_amount_and_set_qc(artifacts)
+        message =  "Amounts have been calculated and qc flags set for all samples."
+        LOG.info(message)
+        click.echo(message)
+    except LimsError as e:
+        LOG.error(e.message)
+        sys.exit(e.message)

--- a/cg_lims/exceptions.py
+++ b/cg_lims/exceptions.py
@@ -18,6 +18,10 @@ class MissingArtifactError(LimsError):
     Eg: Found no artifact for sample X in process Y."""
     pass
 
+class MissingSampleError(LimsError):
+    """Raise when searching for samples that don't exist."""
+    pass
+
 class MissingUDFsError(LimsError):
     """Raise when searching for udfs that don't exist.
     Eg: Found no udf X on artifact Y."""

--- a/cg_lims/exceptions.py
+++ b/cg_lims/exceptions.py
@@ -35,3 +35,7 @@ class LowAmountError(LimsError):
     """Raise when amount is low."""
     pass
 
+class FailingQCError(LimsError):
+    """Raise when qc fails"""
+    pass
+

--- a/cg_lims/get/artifacts.py
+++ b/cg_lims/get/artifacts.py
@@ -26,6 +26,13 @@ def get_artifacts(process: Process, input: bool) -> List[Artifact]:
         artifacts = [a for a in process.all_outputs(unique=True) if a.type == "Analyte"]
     return artifacts
 
+def get_qc_messuements(lims: Lims, process: Process) -> List[Artifact]:
+    """Get output 'artifacts' (messuements) of a qc process"""
+
+    iom = process.input_output_maps
+    artifact_ids = [io[1]['limsid'] for io in iom if io[1]['output-generation-type'] == 'PerInput']
+    return [Artifact(lims, id=id) for id in artifact_ids if id is not None]
+
 
 def filter_artifacts(artifacts: List[Artifact], udf: str, value) -> List[Artifact]:
     """Returning a list of only artifacts with udf==value"""

--- a/cg_lims/get/samples.py
+++ b/cg_lims/get/samples.py
@@ -1,4 +1,5 @@
-from genologics.entities import Process, Sample
+from genologics.entities import Process, Sample, Artifact
+from cg_lims.exceptions import MissingSampleError
 from typing import List
 
 
@@ -11,3 +12,19 @@ def get_process_samples(process: Process) -> List[Sample]:
         all_samples += art.samples
 
     return list(set(all_samples))
+
+def get_artifact_sample(artifact: Artifact)-> Sample:
+    """Checking that a artifact has one and only one sample.
+    Returning the sample if it exists.
+    Raising MissingSampleError otherwise."""
+    
+    try:
+        samples = artifact.samples
+    except:
+        raise MissingSampleError(f"Artifact {artifact.id} has no samples.")
+    if len(samples) > 1:
+        raise MissingSampleError(f"Artifact {artifact.id} has more than one sample.")
+    elif len(samples) == 0:
+        raise MissingSampleError(f"Artifact {artifact.id} has no samples.")
+
+    return samples[0]

--- a/cg_lims/get/samples.py
+++ b/cg_lims/get/samples.py
@@ -22,9 +22,9 @@ def get_artifact_sample(artifact: Artifact)-> Sample:
         samples = artifact.samples
     except:
         raise MissingSampleError(f"Artifact {artifact.id} has no samples.")
-    if len(samples) > 1:
-        raise MissingSampleError(f"Artifact {artifact.id} has more than one sample.")
-    elif len(samples) == 0:
+    if not samples:
         raise MissingSampleError(f"Artifact {artifact.id} has no samples.")
+    elif len(samples) > 1:
+        raise MissingSampleError(f"Artifact {artifact.id} has more than one sample.")
 
     return samples[0]

--- a/tests/EPPs/test_make_kapa_csv.py
+++ b/tests/EPPs/test_make_kapa_csv.py
@@ -20,11 +20,12 @@ def test_get_file_data_and_write_KAPA_library_preparation(
     amount_step = "Aliquot samples for enzymatic fragmentation TWIST"
     entety_data = helpers.read_json(entety_json_data, "make_kapa_csv")
 
-    amount_artifacts = helpers.ensure_lims_artifacts(
-        lims, entety_data["amount_artifacts"]
-    )
     helpers.ensure_lims_process(
-        lims=lims, process_type_name=amount_step, output_artifacts=amount_artifacts
+        lims=lims,
+        data={
+            "process_type": {"name": amount_step},
+            "outputs": entety_data["amount_artifacts"],
+        },
     )
     curent_step_artifacts = helpers.ensure_lims_artifacts(
         lims, entety_data["artifacts_kapa_library_preparation"]
@@ -55,11 +56,12 @@ def test_get_file_data_and_write_Enzymatic_fragmentation(
     amount_step = "Aliquot samples for enzymatic fragmentation TWIST"
     entety_data = helpers.read_json(entety_json_data, "make_kapa_csv")
 
-    amount_artifacts = helpers.ensure_lims_artifacts(
-        lims, entety_data["amount_artifacts"]
-    )
     helpers.ensure_lims_process(
-        lims=lims, process_type_name=amount_step, output_artifacts=amount_artifacts
+        lims=lims,
+        data={
+            "process_type": {"name": amount_step},
+            "outputs": entety_data["amount_artifacts"],
+        },
     )
     curent_step_artifacts = helpers.ensure_lims_artifacts(
         lims, entety_data["artifacts_enzymatic_feragmentation"]
@@ -90,11 +92,12 @@ def test_get_file_data_and_write_missing_udf(
     amount_step = "Aliquot samples for enzymatic fragmentation TWIST"
     entety_data = helpers.read_json(entety_json_data, "make_kapa_csv")
 
-    amount_artifacts = helpers.ensure_lims_artifacts(
-        lims, entety_data["amount_artifacts_missing_udf"]
-    )
     helpers.ensure_lims_process(
-        lims=lims, process_type_name=amount_step, output_artifacts=amount_artifacts
+        lims=lims,
+        data={
+            "process_type": {"name": amount_step},
+            "outputs": entety_data["amount_artifacts_missing_udf"],
+        },
     )
     curent_step_artifacts = helpers.ensure_lims_artifacts(
         lims, entety_data["artifacts_kapa_library_preparation"]

--- a/tests/get/test_artifacts.py
+++ b/tests/get/test_artifacts.py
@@ -5,8 +5,8 @@ import pytest
 
 
 def test_get_latest_artifact(lims, sample, helpers):
-    # GIVEN a lims with a sample that has been run through the same 
-    # type of process twise but on two diferent dates. 
+    # GIVEN a lims with a sample that has been run through the same
+    # type of process twise but on two diferent dates.
     sample_id = "SomeSampleID"
     process_type = "SomeTypeOfProcess"
     first_date = "2019-01-01"
@@ -14,15 +14,22 @@ def test_get_latest_artifact(lims, sample, helpers):
 
     sample.id = sample_id
 
-    helpers.ensure_lims_process(lims = lims,
-        process_type_name=process_type,
-        date_run=first_date,
-        output_artifacts=[helpers.create_artifact(samples=[sample], type="Analyte")],
+    helpers.ensure_lims_process(
+        lims=lims,
+        data={
+            "process_type": {"name": process_type},
+            "date_run": first_date,
+            "outputs": [{"samples": [{"sample_id": sample_id}], "type": "Analyte"}],
+        },
     )
-    helpers.ensure_lims_process(lims = lims,
-        process_type_name=process_type,
-        date_run=last_date,
-        output_artifacts=[helpers.create_artifact(samples=[sample], type="Analyte")],
+
+    helpers.ensure_lims_process(
+        lims=lims,
+        data={
+            "process_type": {"name": process_type},
+            "date_run": last_date,
+            "outputs": [{"samples": [{"sample_id": sample_id}], "type": "Analyte"}],
+        },
     )
 
     # WHEN running get_latest_artifact with the sample id and the process type name
@@ -58,7 +65,7 @@ def test_get_artifacts_no_output_artifacts(process):
 
 def test_get_artifacts_with_output_artifacts(process, helpers):
     # GIVEN a process with five output artifacts
-    five_artifacts = helpers.create_many_artifacts(nr_of_artifacts=5, type='Analyte')
+    five_artifacts = helpers.create_many_artifacts(nr_of_artifacts=5, type="Analyte")
     process.outputs = five_artifacts
 
     # WHEN running get_artifacts
@@ -70,13 +77,12 @@ def test_get_artifacts_with_output_artifacts(process, helpers):
 
 def test_get_artifacts_with_input_artifacts(process, helpers):
     # GIVEN a process with five output artifacts
-    five_artifacts = helpers.create_many_artifacts(nr_of_artifacts=5, type='Analyte')
-    process.inputs = five_artifacts
+    five_artifacts = helpers.create_many_artifacts(nr_of_artifacts=5, type="Analyte")
+    process.input_artifact_list = five_artifacts
 
     # WHEN running get_artifacts
     input_artifacts = get_artifacts(process, input=True)
 
     # THEN assert input_artifacts are five
     assert len(input_artifacts) == 5
-
 


### PR DESCRIPTION
This PR adds a new script to calculate amount and set qc-flaggs for twist qc steps. 
Rewriting the ensure_lims_process to be more similar to the other ensure functions.

### Review:
- [ ] Code approved by
- [x] Tests executed by @cesve @mayabrandi 
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
