### PR TITLE
log warning string wrong

### DIFF
--- a/cg_lims/EPPs/move/rerun_samples.py
+++ b/cg_lims/EPPs/move/rerun_samples.py
@@ -54,7 +54,7 @@ def check_same_sample_in_many_rerun_pools(rerun_arts: List[Artifact]) -> None:
     duplicate_samples = list(set(all_samples))
     if duplicate_samples:
         raise DuplicateSampleError(
-            f"Waring same sample in many pools: {' ,'.join(duplicate_samples)}"
+            f"Waring same sample in many pools: {' ,'.join([sample.id for sample in duplicate_samples])}"
         )
 
 


### PR DESCRIPTION
### This PR fixes little bug in doc string:

### Review:
- [ ] Code approved by
- [x] Tests executed by @mayabrandi 
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
