### PR TITLE
set reads missing

### DIFF
--- a/cg_lims/EPPs/udf/base.py
+++ b/cg_lims/EPPs/udf/base.py
@@ -6,7 +6,7 @@ from cg_lims.EPPs.udf.calculate import calculate
 
 # commands
 from cg_lims.EPPs.udf.copy import copy
-from cg_lims.EPPs.udf.set import set_
+from cg_lims.EPPs.udf.set import set
 
 
 @click.group(invoke_without_command=True)
@@ -18,4 +18,4 @@ def udf(ctx):
 
 udf.add_command(copy)
 udf.add_command(calculate)
-udf.add_command(set_)
+udf.add_command(set)

--- a/cg_lims/EPPs/udf/base.py
+++ b/cg_lims/EPPs/udf/base.py
@@ -6,6 +6,7 @@ from cg_lims.EPPs.udf.calculate import calculate
 
 # commands
 from cg_lims.EPPs.udf.copy import copy
+from cg_lims.EPPs.udf.set import set_
 
 
 @click.group(invoke_without_command=True)
@@ -17,3 +18,4 @@ def udf(ctx):
 
 udf.add_command(copy)
 udf.add_command(calculate)
+udf.add_command(set_)

--- a/cg_lims/EPPs/udf/calculate/base.py
+++ b/cg_lims/EPPs/udf/calculate/base.py
@@ -7,12 +7,13 @@ from cg_lims.EPPs.udf.calculate.calculate_beads import calculate_beads
 from cg_lims.EPPs.udf.calculate.calculate_water import volume_water
 from cg_lims.EPPs.udf.calculate.get_missing_reads import get_missing_reads
 from cg_lims.EPPs.udf.calculate.molar_concentration import molar_concentration
+from cg_lims.EPPs.udf.calculate.sum_missing_reads_in_pool import missing_reads_in_pool
 from cg_lims.EPPs.udf.calculate.twist_aliquot_amount import twist_aliquot_amount
 from cg_lims.EPPs.udf.calculate.twist_aliquot_volume import twist_aliquot_volume
-from cg_lims.EPPs.udf.calculate.twist_get_volumes_from_buffer import get_volumes_from_buffer
-from cg_lims.EPPs.udf.calculate.calculate_water import volume_water
-from cg_lims.EPPs.udf.calculate.molar_concentration import molar_concentration
-from cg_lims.EPPs.udf.calculate.sum_missing_reads_in_pool import missing_reads_in_pool
+from cg_lims.EPPs.udf.calculate.twist_get_volumes_from_buffer import (
+    get_volumes_from_buffer,
+)
+
 # commands
 from cg_lims.EPPs.udf.calculate.twist_pool import twist_pool
 from cg_lims.EPPs.udf.calculate.twist_qc_amount import twist_qc_amount

--- a/cg_lims/EPPs/udf/set/__init__.py
+++ b/cg_lims/EPPs/udf/set/__init__.py
@@ -1,0 +1,1 @@
+from .base import set_

--- a/cg_lims/EPPs/udf/set/__init__.py
+++ b/cg_lims/EPPs/udf/set/__init__.py
@@ -1,1 +1,1 @@
-from .base import set_
+from .base import set

--- a/cg_lims/EPPs/udf/set/base.py
+++ b/cg_lims/EPPs/udf/set/base.py
@@ -1,0 +1,15 @@
+import click
+
+from cg_lims.EPPs.udf.set.set_samples_reads_missing import (
+    set_reads_missing_on_new_samples,
+)
+
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+def set_(context: click.Context):
+    """Main entry point of set commands"""
+    pass
+
+
+set_.add_command(set_reads_missing_on_new_samples)

--- a/cg_lims/EPPs/udf/set/base.py
+++ b/cg_lims/EPPs/udf/set/base.py
@@ -1,15 +1,13 @@
 import click
 
-from cg_lims.EPPs.udf.set.set_samples_reads_missing import (
-    set_reads_missing_on_new_samples,
-)
+from cg_lims.EPPs.udf.set.set_samples_reads_missing import set_reads_missing_on_new_samples
 
 
 @click.group(invoke_without_command=True)
 @click.pass_context
-def set_(context: click.Context):
+def set(context: click.Context):
     """Main entry point of set commands"""
     pass
 
 
-set_.add_command(set_reads_missing_on_new_samples)
+set.add_command(set_reads_missing_on_new_samples)

--- a/cg_lims/EPPs/udf/set/set_samples_reads_missing.py
+++ b/cg_lims/EPPs/udf/set/set_samples_reads_missing.py
@@ -16,10 +16,7 @@ LOG = logging.getLogger(__name__)
 
 def get_target_amount(app_tag: str, status_db: StatusDBAPI) -> int:
     """Gets the target amount of reads from clinical-api"""
-    try:
-        return status_db.apptag(tag_name=app_tag, key="target_reads")
-    except ConnectionError:
-        raise LimsError(message="No connection to clinical-api!")
+    return status_db.apptag(tag_name=app_tag, key="target_reads")
 
 
 def set_reads_missing_on_sample(sample: Sample, status_db: StatusDBAPI) -> None:

--- a/cg_lims/EPPs/udf/set/set_samples_reads_missing.py
+++ b/cg_lims/EPPs/udf/set/set_samples_reads_missing.py
@@ -7,8 +7,8 @@ import click
 from genologics.entities import Sample
 
 from cg_lims.exceptions import LimsError, MissingUDFsError
-from cg_lims.get.fields import get_app_tag
 from cg_lims.get.samples import get_process_samples
+from cg_lims.get.udfs import get_udf
 from cg_lims.status_db_api import StatusDBAPI
 
 LOG = logging.getLogger(__name__)
@@ -24,7 +24,7 @@ def get_target_amount(app_tag: str, status_db: StatusDBAPI) -> int:
 
 def set_reads_missing_on_sample(sample: Sample, status_db: StatusDBAPI) -> None:
     """Sets the udf "Reads missing (M)" on a sample to the target amount of reads bases on the app tag"""
-    app_tag = get_app_tag(sample)
+    app_tag = get_udf(sample, "Sequencing Analysis")
     target_amount = get_target_amount(app_tag, status_db)
     sample.udf["Reads missing (M)"] = target_amount / 1000000
     sample.put()

--- a/cg_lims/EPPs/udf/set/set_samples_reads_missing.py
+++ b/cg_lims/EPPs/udf/set/set_samples_reads_missing.py
@@ -1,0 +1,78 @@
+"""CLI module to set Reads Missing (M) udf on new samples"""
+import logging
+import sys
+from typing import List
+
+import click
+from genologics.entities import Sample
+
+from cg_lims.exceptions import LimsError, MissingCgFieldError, MissingUDFsError
+from cg_lims.get.samples import get_process_samples
+from cg_lims.status_db_api import StatusDBAPI
+
+LOG = logging.getLogger(__name__)
+PASSED = "PASSED"
+FAILED = "FAILED"
+
+
+def set_reads_missing_on_sample(sample: Sample, status_db: StatusDBAPI):
+    """ """
+    app_tag = get_app_tag(sample)
+    target_amount = get_target_amount(app_tag, status_db)
+    sample.udf["Reads missing (M)"] = target_amount / 1000000
+    sample.put()
+
+
+def get_app_tag(sample: Sample):
+    """ """
+    try:
+        return sample.udf["Sequencing Analysis"]
+    except Exception:
+        raise MissingUDFsError(
+            f"UDF Sequencing Analysis not found on sample {sample.id}!"
+        )
+
+
+def get_target_amount(app_tag: str, status_db: StatusDBAPI):
+    """ """
+    try:
+        return status_db.apptag(tag_name=app_tag, key="target_reads")
+    except ConnectionError:
+        raise LimsError(message="No connection to clinical-api!")
+
+
+def set_reads_missing(samples: List[Sample], status_db: StatusDBAPI):
+    """ """
+    failed_samples = 0
+    for sample in samples:
+        try:
+            set_reads_missing_on_sample(sample, status_db)
+        except Exception:
+            failed_samples += 1
+    return failed_samples
+
+
+@click.command()
+@click.pass_context
+def set_reads_missing_on_new_samples(context: click.Context):
+    """Set Reads Missing (M) udf on samples before they go into any workflow"""
+
+    LOG.info(f"Running {context.command_path} with params: {context.params}")
+
+    process = context.obj["process"]
+    status_db = context.obj["status_db"]
+
+    try:
+        samples = get_process_samples(process=process)
+        failed_samples = set_reads_missing(samples, status_db)
+        message = "Reads Missing (M) udf set on samples."
+        if failed_samples:
+            LOG.error(message)
+            click.echo(message)
+        else:
+            LOG.info(message)
+            click.echo(message)
+    except LimsError as e:
+        LOG.error(e.message)
+        sys.exit(e.message)
+        pass

--- a/cg_lims/EPPs/udf/set/set_samples_reads_missing.py
+++ b/cg_lims/EPPs/udf/set/set_samples_reads_missing.py
@@ -82,4 +82,3 @@ def set_reads_missing_on_new_samples(context: click.Context):
     except LimsError as e:
         LOG.error(e.message)
         sys.exit(e.message)
-        pass

--- a/cg_lims/get/fields.py
+++ b/cg_lims/get/fields.py
@@ -1,10 +1,12 @@
 import datetime as dt
+import logging
+from typing import Optional, Tuple
 
 from genologics.descriptors import LocationDescriptor
+from genologics.entities import Artifact, Sample
 from requests.exceptions import HTTPError
-from genologics.entities import Sample, Artifact
-from typing import Optional, Tuple
-import logging
+
+from cg_lims.exceptions import MissingUDFsError
 
 LOG = logging.getLogger(__name__)
 
@@ -84,3 +86,13 @@ def get_index_well(artifact: Artifact):
         return f"{index_well_row}{index_well_col}"
     else:
         return "-"
+
+
+def get_app_tag(sample: Sample) -> str:
+    """ """
+    try:
+        return sample.udf["Sequencing Analysis"]
+    except Exception:
+        raise MissingUDFsError(
+            f"UDF Sequencing Analysis not found on sample {sample.id}!"
+        )

--- a/cg_lims/get/fields.py
+++ b/cg_lims/get/fields.py
@@ -2,11 +2,8 @@ import datetime as dt
 import logging
 from typing import Optional, Tuple
 
-from genologics.descriptors import LocationDescriptor
 from genologics.entities import Artifact, Sample
 from requests.exceptions import HTTPError
-
-from cg_lims.exceptions import MissingUDFsError
 
 LOG = logging.getLogger(__name__)
 
@@ -86,13 +83,3 @@ def get_index_well(artifact: Artifact):
         return f"{index_well_row}{index_well_col}"
     else:
         return "-"
-
-
-def get_app_tag(sample: Sample) -> str:
-    """ """
-    try:
-        return sample.udf["Sequencing Analysis"]
-    except Exception:
-        raise MissingUDFsError(
-            f"UDF Sequencing Analysis not found on sample {sample.id}!"
-        )

--- a/cg_lims/get/udfs.py
+++ b/cg_lims/get/udfs.py
@@ -1,6 +1,10 @@
-from genologics.lims import Lims
-from typing import Optional
 from datetime import date
+from typing import Optional
+
+from genologics.entities import Sample
+from genologics.lims import Lims
+
+from cg_lims.exceptions import MissingUDFsError
 
 
 def get_udf_type(lims: Lims, udf_name: str, attach_to_name: str) -> Optional:
@@ -19,3 +23,13 @@ def get_udf_type(lims: Lims, udf_name: str, attach_to_name: str) -> Optional:
     udf_type = udf_configs[0].root.attrib["type"]
 
     return udf_types[udf_type]
+
+
+def get_udf(sample: Sample, udf: str) -> str:
+    """ """
+    try:
+        return sample.udf[udf]
+    except Exception:
+        raise MissingUDFsError(
+            f"UDF Sequencing Analysis not found on sample {sample.id}!"
+        )

--- a/cg_lims/get/udfs.py
+++ b/cg_lims/get/udfs.py
@@ -26,7 +26,7 @@ def get_udf_type(lims: Lims, udf_name: str, attach_to_name: str) -> Optional:
 
 
 def get_udf(sample: Sample, udf: str) -> str:
-    """ """
+    """Returns the value of a udf on a sample"""
     try:
         return sample.udf[udf]
     except Exception:

--- a/cg_lims/get/udfs.py
+++ b/cg_lims/get/udfs.py
@@ -30,6 +30,4 @@ def get_udf(sample: Sample, udf: str) -> str:
     try:
         return sample.udf[udf]
     except Exception:
-        raise MissingUDFsError(
-            f"UDF Sequencing Analysis not found on sample {sample.id}!"
-        )
+        raise MissingUDFsError(f"UDF {udf} not found on sample {sample.id}!")

--- a/cg_lims/status_db_api.py
+++ b/cg_lims/status_db_api.py
@@ -2,14 +2,19 @@ import json
 
 import requests
 
+from cg_lims.exceptions import LimsError
+
 
 class StatusDBAPI(object):
     def __init__(self, url=None):
         self.url = url
 
     def apptag(self, tag_name, key=None, entry_point="/applications"):
-        res = requests.get(self.url + entry_point + "/" + tag_name)
-        if key:
-            return json.loads(res.text)[key]
-        else:
-            return json.loads(res.text)
+        try:
+            res = requests.get(self.url + entry_point + "/" + tag_name)
+            if key:
+                return json.loads(res.text)[key]
+            else:
+                return json.loads(res.text)
+        except ConnectionError:
+            raise LimsError(message="No connection to clinical-api!")

--- a/tests/EPPs/test_set_samples_reads_missing.py
+++ b/tests/EPPs/test_set_samples_reads_missing.py
@@ -99,7 +99,7 @@ def test_set_reads_missing_one_sample(
     samples = [sample_1]
 
     # WHEN setting the reads missing on that sample
-    failed_samples_count, failed_samples = set_reads_missing(
+    failed_samples_count, succeeded_samples_count, failed_samples = set_reads_missing(
         samples, status_db=mock_status_db
     )
 
@@ -107,6 +107,7 @@ def test_set_reads_missing_one_sample(
     mock_set_reads_missing_on_sample.assert_called_with(sample_1, mock_status_db)
     # AND there should be no failed samples
     assert failed_samples_count == 0
+    assert succeeded_samples_count == 1
     assert bool(failed_samples) is False
 
 
@@ -121,7 +122,7 @@ def test_set_reads_missing_multiple_samples(
     samples = [sample_1, sample_2]
 
     # WHEN setting the reads missing on those samples
-    failed_samples_count, failed_samples = set_reads_missing(
+    failed_samples_count, succeeded_samples_count, failed_samples = set_reads_missing(
         samples, status_db=mock_status_db
     )
 
@@ -132,6 +133,7 @@ def test_set_reads_missing_multiple_samples(
     ]
     # AND there should be no failed samples
     assert failed_samples_count == 0
+    assert succeeded_samples_count == 2
     assert bool(failed_samples) is False
 
 
@@ -149,11 +151,14 @@ def test_set_reads_missing_one_sample_exception(
 
     # WHEN setting the reads missing on that sample leads to an exception  being raised
     mock_set_reads_missing_on_sample.side_effect = Exception
-    failed_samples_count, failed_samples = set_reads_missing(samples, mock_status_db)
+    failed_samples_count, succeeded_samples_count, failed_samples = set_reads_missing(
+        samples, mock_status_db
+    )
 
     # AND one failed sample should be counted, and it's id should be returned
     mock_set_reads_missing_on_sample.assert_called_with(sample_1, mock_status_db)
     assert failed_samples_count == 1
+    assert succeeded_samples_count == 0
     assert failed_samples == ["S1"]
 
 
@@ -172,7 +177,9 @@ def test_set_reads_missing_multiple_samples_exception_on_first_sample(
 
     # WHEN setting the reads missing on those samples and the second sample leads to an exception being raised
     mock_set_reads_missing_on_sample.side_effect = (None, Exception)
-    failed_samples_count, failed_samples = set_reads_missing(samples, mock_status_db)
+    failed_samples_count, succeeded_samples_count, failed_samples = set_reads_missing(
+        samples, mock_status_db
+    )
 
     # THEN setting the missing reads should be attempted for both samples
     assert mock_set_reads_missing_on_sample.mock_calls == [
@@ -181,6 +188,7 @@ def test_set_reads_missing_multiple_samples_exception_on_first_sample(
     ]
     # AND one failed sample should be counted, and it's id should be returned
     assert failed_samples_count == 1
+    assert succeeded_samples_count == 1
     assert failed_samples == ["S2"]
 
 
@@ -201,7 +209,9 @@ def test_set_reads_missing_multiple_samples_exception_on_second_sample(
     # WHEN setting the reads missing on those samples and the first sample leads to an exception being raised
 
     mock_set_reads_missing_on_sample.side_effect = (Exception, None)
-    failed_samples_count, failed_samples = set_reads_missing(samples, mock_status_db)
+    failed_samples_count, succeeded_samples_count, failed_samples = set_reads_missing(
+        samples, mock_status_db
+    )
 
     # THEN setting the missing reads should be attempted for both samples
     assert mock_set_reads_missing_on_sample.mock_calls == [
@@ -210,6 +220,7 @@ def test_set_reads_missing_multiple_samples_exception_on_second_sample(
     ]
     # AND one failed sample should be counted
     assert failed_samples_count == 1
+    assert succeeded_samples_count == 1
     assert failed_samples == ["S1"]
 
 
@@ -229,7 +240,9 @@ def test_set_reads_missing_multiple_samples_exception_on_both_samples(
 
     # WHEN setting the reads missing on those samples and both samples leads to an exception being raised
     mock_set_reads_missing_on_sample.side_effect = (Exception, Exception)
-    failed_samples_count, failed_samples = set_reads_missing(samples, mock_status_db)
+    failed_samples_count, succeeded_samples_count, failed_samples = set_reads_missing(
+        samples, mock_status_db
+    )
 
     # THEN setting the missing reads should be attempted for both samples
     assert mock_set_reads_missing_on_sample.mock_calls == [
@@ -238,4 +251,5 @@ def test_set_reads_missing_multiple_samples_exception_on_both_samples(
     ]
     # AND two failed sample should be counted, and their id's should be returned
     assert failed_samples_count == 2
+    assert succeeded_samples_count == 0
     assert failed_samples == ["S1", "S2"]

--- a/tests/EPPs/test_set_samples_reads_missing.py
+++ b/tests/EPPs/test_set_samples_reads_missing.py
@@ -3,8 +3,8 @@ import pytest
 from genologics.entities import Sample
 
 from cg_lims.EPPs.udf.set.set_samples_reads_missing import (
-    get_app_tag,
     get_target_amount,
+    get_udf,
     set_reads_missing,
     set_reads_missing_on_sample,
 )
@@ -16,9 +16,9 @@ server("flat_tests")
 
 @mock.patch("cg_lims.status_db_api.StatusDBAPI")
 @mock.patch("cg_lims.EPPs.udf.set.set_samples_reads_missing.get_target_amount")
-@mock.patch("cg_lims.EPPs.udf.set.set_samples_reads_missing.get_app_tag")
+@mock.patch("cg_lims.EPPs.udf.set.set_samples_reads_missing.get_udf")
 def test_set_reads_missing_on_sample(
-    mock_get_app_tag,
+    mock_get_udf,
     mock_get_target_amount,
     mock_status_db,
     sample_1: Sample,
@@ -34,32 +34,6 @@ def test_set_reads_missing_on_sample(
 
     # THEN the udf "Reads missing (M)" on that sample should be set correctly
     assert sample.udf["Reads missing (M)"] == 9
-
-
-def test_get_app_tag(sample_1: Sample):
-    # GIVEN a sample with a udf "Sequencing Analysis"
-    sample_1.udf["Sequencing Analysis"] = "TESTAPPTAG"
-
-    # WHEN getting the apptag for that sample
-    result = get_app_tag(sample_1)
-
-    # THEN the apptag should be returned
-    assert result == "TESTAPPTAG"
-
-
-def test_get_app_tag_missing_udf(sample_1: Sample):
-    # GIVEN a sample with a missing udf "Sequencing Analysis"
-    assert sample_1.udf.get("Sequencing Analysis") is None
-
-    # WHEN getting the apptag for that sample
-    with pytest.raises(MissingUDFsError) as error_message:
-        get_app_tag(sample_1)
-
-    # THEN the correct exception should be raised
-    assert (
-        f"UDF Sequencing Analysis not found on sample {sample_1.id}"
-        in error_message.value.message
-    )
 
 
 @mock.patch("cg_lims.status_db_api.StatusDBAPI")

--- a/tests/EPPs/test_set_samples_reads_missing.py
+++ b/tests/EPPs/test_set_samples_reads_missing.py
@@ -11,6 +11,8 @@ from cg_lims.EPPs.udf.set.set_samples_reads_missing import (
 from cg_lims.exceptions import LimsError, MissingUDFsError
 from tests.conftest import server
 
+server("flat_tests")
+
 
 @mock.patch("cg_lims.status_db_api.StatusDBAPI")
 @mock.patch("cg_lims.EPPs.udf.set.set_samples_reads_missing.get_target_amount")
@@ -21,7 +23,6 @@ def test_set_reads_missing_on_sample(
     mock_status_db,
     sample_1: Sample,
 ):
-    server("flat_tests")
 
     # GIVEN A SAMPLE
     sample = sample_1

--- a/tests/EPPs/test_set_samples_reads_missing.py
+++ b/tests/EPPs/test_set_samples_reads_missing.py
@@ -1,0 +1,161 @@
+import mock
+import pytest
+from genologics.entities import Sample
+
+from cg_lims.EPPs.udf.set.set_samples_reads_missing import (
+    get_app_tag,
+    get_target_amount,
+    set_reads_missing,
+    set_reads_missing_on_sample,
+)
+from cg_lims.exceptions import LimsError, MissingUDFsError
+from tests.conftest import server
+
+
+@mock.patch("cg_lims.status_db_api.StatusDBAPI")
+@mock.patch("cg_lims.EPPs.udf.set.set_samples_reads_missing.get_target_amount")
+@mock.patch("cg_lims.EPPs.udf.set.set_samples_reads_missing.get_app_tag")
+def test_set_reads_missing_on_sample(
+    mock_get_app_tag, mock_get_target_amount, mock_status_db, sample_1: Sample
+):
+    """ """
+    server("flat_tests")
+
+    # GIVEN A SAMPLE
+    sample = sample_1
+
+    # WHEN setting the missing reads on that sample_1
+    mock_get_target_amount.return_value = 9_000_000
+
+    set_reads_missing_on_sample(sample_1, mock_status_db)
+
+    # THEN the udf "Reads missing (M)" on that sample should be set
+    assert sample_1.udf["Reads missing (M)"] == 9
+
+
+def test_get_app_tag(sample_1: Sample):
+    """ """
+    # GIVEN a sample with a udf "Sequencing Analysis"
+    sample_1.udf["Sequencing Analysis"] = "TESTAPPTAG"
+
+    # WHEN getting the apptag for that sample
+    result = get_app_tag(sample_1)
+
+    # THEN the apptag should be returned
+    assert result == "TESTAPPTAG"
+
+
+def test_get_app_tag_missing_udf(sample_1: Sample):
+    """ """
+    # GIVEN a sample with a missing udf "Sequencing Analysis"
+
+    # WHEN getting the apptag for that sample
+    with pytest.raises(MissingUDFsError) as error_message:
+        get_app_tag(sample_1)
+
+    # THEN
+    assert (
+        f"UDF Sequencing Analysis not found on sample {sample_1.id}"
+        in error_message.value.message
+    )
+
+
+@mock.patch("cg_lims.status_db_api.StatusDBAPI")
+def test_get_target_amount(mock_status_db):
+    """ """
+    # GIVEN an apptag
+    apptag = "TESTAPPTAG"
+
+    # WHEN fetching the target amount
+    mock_status_db.apptag.return_value = 9_000_000
+    result = get_target_amount(apptag, mock_status_db)
+
+    # THEN the correct value should be returned
+    assert result == 9_000_000
+
+
+@mock.patch("cg_lims.status_db_api.StatusDBAPI")
+def test_get_target_amount_connection_error(mock_status_db):
+    """ """
+    # GIVEN a connection error
+    apptag = "TESTAPPTAG"
+    mock_status_db.apptag.side_effect = ConnectionError
+
+    # WHEN fetching the target amount
+    with pytest.raises(LimsError) as error_message:
+        get_target_amount(apptag, mock_status_db)
+
+    # THEN
+    assert f"No connection to clinical-api!" in error_message.value.message
+
+
+@mock.patch(
+    "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
+)
+@mock.patch("cg_lims.status_db_api.StatusDBAPI")
+def test_set_reads_missing_one_sample(
+    mock_status_db, mock_set_reads_missing_on_sample, sample_1: Sample
+):
+    """ """
+
+    # GIVEN a single sample
+    samples = [sample_1]
+
+    # WHEN setting the reads missing on those samples
+    result = set_reads_missing(samples, status_db=mock_status_db)
+
+    # THEN
+    mock_set_reads_missing_on_sample.assert_called_with(sample_1, mock_status_db)
+    assert result == 0
+
+
+@mock.patch(
+    "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
+)
+@mock.patch("cg_lims.status_db_api.StatusDBAPI")
+def test_set_reads_missing_multiple_samples(
+    mock_status_db, mock_set_reads_missing_on_sample, sample_1: Sample, sample_2: Sample
+):
+    """ """
+
+    # GIVEN a list of samples
+    samples = [sample_1, sample_2]
+
+    # WHEN setting the reads missing on those samples
+    result = set_reads_missing(samples, status_db=mock_status_db)
+
+    # THEN the missing reads should be set on both samples
+    assert mock_set_reads_missing_on_sample.call_count == 2
+    mock_set_reads_missing_on_sample.assert_has_calls(
+        [
+            mock.call(sample_1, mock_status_db),
+            mock.call(sample_2, mock_status_db),
+        ]
+    )
+    assert mock_set_reads_missing_on_sample.mock_calls == [
+        mock.call(sample_1, mock_status_db),
+        mock.call(sample_2, mock_status_db),
+    ]
+    assert result == 0
+
+
+@mock.patch(
+    "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
+)
+@mock.patch("cg_lims.status_db_api.StatusDBAPI")
+def test_set_reads_missing_one_sample_exception(
+    mock_status_db, mock_set_reads_missing_on_sample, sample_1: Sample
+):
+    """ """
+
+    # GIVEN a single sample
+    samples = [sample_1]
+    mock_set_reads_missing_on_sample.side_effect = Exception
+
+    # WHEN setting the reads missing on those samples
+    with pytest.raises(Exception):
+        result = set_reads_missing(samples, mock_status_db)
+
+    # THEN
+    mock_set_reads_missing_on_sample.assert_called_with(sample_1, mock_status_db)
+    assert result == 1

--- a/tests/EPPs/test_set_samples_reads_missing.py
+++ b/tests/EPPs/test_set_samples_reads_missing.py
@@ -21,7 +21,7 @@ def test_set_reads_missing_on_sample(
     mock_status_db,
     sample_1: Sample,
 ):
-    server("flat_tests")
+    # server("flat_tests")
     # GIVEN A SAMPLE
     sample = sample_1
 

--- a/tests/EPPs/test_set_samples_reads_missing.py
+++ b/tests/EPPs/test_set_samples_reads_missing.py
@@ -16,25 +16,26 @@ from tests.conftest import server
 @mock.patch("cg_lims.EPPs.udf.set.set_samples_reads_missing.get_target_amount")
 @mock.patch("cg_lims.EPPs.udf.set.set_samples_reads_missing.get_app_tag")
 def test_set_reads_missing_on_sample(
-    mock_get_app_tag, mock_get_target_amount, mock_status_db, sample_1: Sample
+    mock_get_app_tag,
+    mock_get_target_amount,
+    mock_status_db,
+    sample_1: Sample,
 ):
-    """ """
     server("flat_tests")
 
     # GIVEN A SAMPLE
     sample = sample_1
 
-    # WHEN setting the missing reads on that sample_1
+    # WHEN setting the missing reads on that sample_1 based on the target amount
     mock_get_target_amount.return_value = 9_000_000
 
-    set_reads_missing_on_sample(sample_1, mock_status_db)
+    set_reads_missing_on_sample(sample, mock_status_db)
 
-    # THEN the udf "Reads missing (M)" on that sample should be set
-    assert sample_1.udf["Reads missing (M)"] == 9
+    # THEN the udf "Reads missing (M)" on that sample should be set correctly
+    assert sample.udf["Reads missing (M)"] == 9
 
 
 def test_get_app_tag(sample_1: Sample):
-    """ """
     # GIVEN a sample with a udf "Sequencing Analysis"
     sample_1.udf["Sequencing Analysis"] = "TESTAPPTAG"
 
@@ -46,14 +47,14 @@ def test_get_app_tag(sample_1: Sample):
 
 
 def test_get_app_tag_missing_udf(sample_1: Sample):
-    """ """
     # GIVEN a sample with a missing udf "Sequencing Analysis"
+    assert sample_1.udf.get("Sequencing Analysis") is None
 
     # WHEN getting the apptag for that sample
     with pytest.raises(MissingUDFsError) as error_message:
         get_app_tag(sample_1)
 
-    # THEN
+    # THEN the correct exception should be raised
     assert (
         f"UDF Sequencing Analysis not found on sample {sample_1.id}"
         in error_message.value.message
@@ -62,22 +63,20 @@ def test_get_app_tag_missing_udf(sample_1: Sample):
 
 @mock.patch("cg_lims.status_db_api.StatusDBAPI")
 def test_get_target_amount(mock_status_db):
-    """ """
     # GIVEN an apptag
     apptag = "TESTAPPTAG"
 
-    # WHEN fetching the target amount
+    # WHEN fetching the target amount from clinical-api
     mock_status_db.apptag.return_value = 9_000_000
     result = get_target_amount(apptag, mock_status_db)
 
-    # THEN the correct value should be returned
+    # THEN the get_target_amount should return that value
     assert result == 9_000_000
 
 
 @mock.patch("cg_lims.status_db_api.StatusDBAPI")
 def test_get_target_amount_connection_error(mock_status_db):
-    """ """
-    # GIVEN a connection error
+    # GIVEN a clinical-api can't be reached due to a connection error
     apptag = "TESTAPPTAG"
     mock_status_db.apptag.side_effect = ConnectionError
 
@@ -85,7 +84,7 @@ def test_get_target_amount_connection_error(mock_status_db):
     with pytest.raises(LimsError) as error_message:
         get_target_amount(apptag, mock_status_db)
 
-    # THEN
+    # THEN the correct exception should be raised
     assert f"No connection to clinical-api!" in error_message.value.message
 
 
@@ -96,17 +95,19 @@ def test_get_target_amount_connection_error(mock_status_db):
 def test_set_reads_missing_one_sample(
     mock_status_db, mock_set_reads_missing_on_sample, sample_1: Sample
 ):
-    """ """
-
     # GIVEN a single sample
     samples = [sample_1]
 
-    # WHEN setting the reads missing on those samples
-    result = set_reads_missing(samples, status_db=mock_status_db)
+    # WHEN setting the reads missing on that sample
+    failed_samples_count, failed_samples = set_reads_missing(
+        samples, status_db=mock_status_db
+    )
 
-    # THEN
+    # THEN set_missing_reads should be called for that sample
     mock_set_reads_missing_on_sample.assert_called_with(sample_1, mock_status_db)
-    assert result == 0
+    # AND there should be no failed samples
+    assert failed_samples_count == 0
+    assert bool(failed_samples) is False
 
 
 @mock.patch(
@@ -116,27 +117,22 @@ def test_set_reads_missing_one_sample(
 def test_set_reads_missing_multiple_samples(
     mock_status_db, mock_set_reads_missing_on_sample, sample_1: Sample, sample_2: Sample
 ):
-    """ """
-
-    # GIVEN a list of samples
+    # GIVEN multiple of samples
     samples = [sample_1, sample_2]
 
     # WHEN setting the reads missing on those samples
-    result = set_reads_missing(samples, status_db=mock_status_db)
+    failed_samples_count, failed_samples = set_reads_missing(
+        samples, status_db=mock_status_db
+    )
 
     # THEN the missing reads should be set on both samples
-    assert mock_set_reads_missing_on_sample.call_count == 2
-    mock_set_reads_missing_on_sample.assert_has_calls(
-        [
-            mock.call(sample_1, mock_status_db),
-            mock.call(sample_2, mock_status_db),
-        ]
-    )
     assert mock_set_reads_missing_on_sample.mock_calls == [
         mock.call(sample_1, mock_status_db),
         mock.call(sample_2, mock_status_db),
     ]
-    assert result == 0
+    # AND there should be no failed samples
+    assert failed_samples_count == 0
+    assert bool(failed_samples) is False
 
 
 @mock.patch(
@@ -144,18 +140,102 @@ def test_set_reads_missing_multiple_samples(
 )
 @mock.patch("cg_lims.status_db_api.StatusDBAPI")
 def test_set_reads_missing_one_sample_exception(
-    mock_status_db, mock_set_reads_missing_on_sample, sample_1: Sample
+    mock_status_db,
+    mock_set_reads_missing_on_sample,
+    sample_1: Sample,
 ):
-    """ """
-
     # GIVEN a single sample
     samples = [sample_1]
+
+    # WHEN setting the reads missing on that sample leads to an exception  being raised
     mock_set_reads_missing_on_sample.side_effect = Exception
+    failed_samples_count, failed_samples = set_reads_missing(samples, mock_status_db)
 
-    # WHEN setting the reads missing on those samples
-    with pytest.raises(Exception):
-        result = set_reads_missing(samples, mock_status_db)
-
-    # THEN
+    # AND one failed sample should be counted, and it's id should be returned
     mock_set_reads_missing_on_sample.assert_called_with(sample_1, mock_status_db)
-    assert result == 1
+    assert failed_samples_count == 1
+    assert failed_samples == ["S1"]
+
+
+@mock.patch(
+    "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
+)
+@mock.patch("cg_lims.status_db_api.StatusDBAPI")
+def test_set_reads_missing_multiple_samples_exception_on_first_sample(
+    mock_status_db,
+    mock_set_reads_missing_on_sample,
+    sample_1: Sample,
+    sample_2: Sample,
+):
+    # GIVEN multiple samples
+    samples = [sample_1, sample_2]
+
+    # WHEN setting the reads missing on those samples and the second sample leads to an exception being raised
+    mock_set_reads_missing_on_sample.side_effect = (None, Exception)
+    failed_samples_count, failed_samples = set_reads_missing(samples, mock_status_db)
+
+    # THEN setting the missing reads should be attempted for both samples
+    assert mock_set_reads_missing_on_sample.mock_calls == [
+        mock.call(sample_1, mock_status_db),
+        mock.call(sample_2, mock_status_db),
+    ]
+    # AND one failed sample should be counted, and it's id should be returned
+    assert failed_samples_count == 1
+    assert failed_samples == ["S2"]
+
+
+@mock.patch(
+    "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
+)
+@mock.patch("cg_lims.status_db_api.StatusDBAPI")
+def test_set_reads_missing_multiple_samples_exception_on_second_sample(
+    mock_status_db,
+    mock_set_reads_missing_on_sample,
+    sample_1: Sample,
+    sample_2: Sample,
+):
+    # GIVEN multiple samples
+    samples = [sample_1, sample_2]
+    assert sample_1.udf.get("Sequencing Analysis") is None
+
+    # WHEN setting the reads missing on those samples and the first sample leads to an exception being raised
+
+    mock_set_reads_missing_on_sample.side_effect = (Exception, None)
+    failed_samples_count, failed_samples = set_reads_missing(samples, mock_status_db)
+
+    # THEN setting the missing reads should be attempted for both samples
+    assert mock_set_reads_missing_on_sample.mock_calls == [
+        mock.call(sample_1, mock_status_db),
+        mock.call(sample_2, mock_status_db),
+    ]
+    # AND one failed sample should be counted
+    assert failed_samples_count == 1
+    assert failed_samples == ["S1"]
+
+
+@mock.patch(
+    "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
+)
+@mock.patch("cg_lims.status_db_api.StatusDBAPI")
+def test_set_reads_missing_multiple_samples_exception_on_both_samples(
+    mock_status_db,
+    mock_set_reads_missing_on_sample,
+    sample_1: Sample,
+    sample_2: Sample,
+):
+    # GIVEN multiple samples
+    samples = [sample_1, sample_2]
+    assert sample_1.udf.get("Sequencing Analysis") is None
+
+    # WHEN setting the reads missing on those samples and both samples leads to an exception being raised
+    mock_set_reads_missing_on_sample.side_effect = (Exception, Exception)
+    failed_samples_count, failed_samples = set_reads_missing(samples, mock_status_db)
+
+    # THEN setting the missing reads should be attempted for both samples
+    assert mock_set_reads_missing_on_sample.mock_calls == [
+        mock.call(sample_1, mock_status_db),
+        mock.call(sample_2, mock_status_db),
+    ]
+    # AND two failed sample should be counted, and their id's should be returned
+    assert failed_samples_count == 2
+    assert failed_samples == ["S1", "S2"]

--- a/tests/EPPs/test_set_samples_reads_missing.py
+++ b/tests/EPPs/test_set_samples_reads_missing.py
@@ -21,7 +21,7 @@ def test_set_reads_missing_on_sample(
     mock_status_db,
     sample_1: Sample,
 ):
-    # server("flat_tests")
+    server("flat_tests")
     # GIVEN A SAMPLE
     sample = sample_1
 

--- a/tests/EPPs/test_set_samples_reads_missing.py
+++ b/tests/EPPs/test_set_samples_reads_missing.py
@@ -150,7 +150,7 @@ def test_set_reads_missing_one_sample_exception(
     samples = [sample_1]
 
     # WHEN setting the reads missing on that sample leads to an exception  being raised
-    mock_set_reads_missing_on_sample.side_effect = Exception
+    mock_set_reads_missing_on_sample.side_effect = MissingUDFsError("TEST MISSING UDF")
     failed_samples_count, succeeded_samples_count, failed_samples = set_reads_missing(
         samples, mock_status_db
     )
@@ -176,7 +176,10 @@ def test_set_reads_missing_multiple_samples_exception_on_first_sample(
     samples = [sample_1, sample_2]
 
     # WHEN setting the reads missing on those samples and the second sample leads to an exception being raised
-    mock_set_reads_missing_on_sample.side_effect = (None, Exception)
+    mock_set_reads_missing_on_sample.side_effect = (
+        None,
+        MissingUDFsError("TEST MISSING UDF"),
+    )
     failed_samples_count, succeeded_samples_count, failed_samples = set_reads_missing(
         samples, mock_status_db
     )
@@ -208,7 +211,10 @@ def test_set_reads_missing_multiple_samples_exception_on_second_sample(
 
     # WHEN setting the reads missing on those samples and the first sample leads to an exception being raised
 
-    mock_set_reads_missing_on_sample.side_effect = (Exception, None)
+    mock_set_reads_missing_on_sample.side_effect = (
+        MissingUDFsError("TEST MISSING UDF"),
+        None,
+    )
     failed_samples_count, succeeded_samples_count, failed_samples = set_reads_missing(
         samples, mock_status_db
     )
@@ -239,7 +245,10 @@ def test_set_reads_missing_multiple_samples_exception_on_both_samples(
     assert sample_1.udf.get("Sequencing Analysis") is None
 
     # WHEN setting the reads missing on those samples and both samples leads to an exception being raised
-    mock_set_reads_missing_on_sample.side_effect = (Exception, Exception)
+    mock_set_reads_missing_on_sample.side_effect = (
+        MissingUDFsError("TEST MISSING UDF"),
+        MissingUDFsError("TEST MISSING UDF"),
+    )
     failed_samples_count, succeeded_samples_count, failed_samples = set_reads_missing(
         samples, mock_status_db
     )

--- a/tests/EPPs/test_set_samples_reads_missing.py
+++ b/tests/EPPs/test_set_samples_reads_missing.py
@@ -1,6 +1,5 @@
 import mock
 import pytest
-from click.testing import CliRunner
 from genologics.entities import Sample
 
 from cg_lims.EPPs.udf.set.set_samples_reads_missing import (

--- a/tests/EPPs/test_set_samples_reads_missing.py
+++ b/tests/EPPs/test_set_samples_reads_missing.py
@@ -11,8 +11,6 @@ from cg_lims.EPPs.udf.set.set_samples_reads_missing import (
 from cg_lims.exceptions import LimsError, MissingUDFsError
 from tests.conftest import server
 
-server("flat_tests")
-
 
 @mock.patch("cg_lims.status_db_api.StatusDBAPI")
 @mock.patch("cg_lims.EPPs.udf.set.set_samples_reads_missing.get_target_amount")
@@ -23,7 +21,7 @@ def test_set_reads_missing_on_sample(
     mock_status_db,
     sample_1: Sample,
 ):
-
+    server("flat_tests")
     # GIVEN A SAMPLE
     sample = sample_1
 

--- a/tests/get/test_fields.py
+++ b/tests/get/test_fields.py
@@ -1,0 +1,34 @@
+import pytest
+from genologics.entities import Sample
+
+from cg_lims.exceptions import MissingUDFsError
+from cg_lims.get.fields import get_app_tag
+from tests.conftest import server
+
+server("flat_tests")
+
+
+def test_get_app_tag(sample_1: Sample):
+    # GIVEN a sample with a udf "Sequencing Analysis"
+    sample_1.udf["Sequencing Analysis"] = "TESTAPPTAG"
+
+    # WHEN getting the apptag for that sample
+    result = get_app_tag(sample_1)
+
+    # THEN the apptag should be returned
+    assert result == "TESTAPPTAG"
+
+
+def test_get_app_tag_missing_udf(sample_1: Sample):
+    # GIVEN a sample with a missing udf "Sequencing Analysis"
+    assert sample_1.udf.get("Sequencing Analysis") is None
+
+    # WHEN getting the apptag for that sample
+    with pytest.raises(MissingUDFsError) as error_message:
+        get_app_tag(sample_1)
+
+    # THEN the correct exception should be raised
+    assert (
+        f"UDF Sequencing Analysis not found on sample {sample_1.id}"
+        in error_message.value.message
+    )

--- a/tests/get/test_udfs.py
+++ b/tests/get/test_udfs.py
@@ -5,11 +5,10 @@ from cg_lims.exceptions import MissingUDFsError
 from cg_lims.get.udfs import get_udf
 from tests.conftest import server
 
-server("flat_tests")
-
 
 def test_get_udf(sample_1: Sample):
     # GIVEN a sample with a udf "Sequencing Analysis"
+    server("flat_tests")
     sample_1.udf["Sequencing Analysis"] = "TESTAPPTAG"
 
     # WHEN getting the apptag for that sample

--- a/tests/get/test_udfs.py
+++ b/tests/get/test_udfs.py
@@ -1,33 +1,33 @@
-import pytest
-from genologics.entities import Sample
-
-from cg_lims.exceptions import MissingUDFsError
-from cg_lims.get.udfs import get_udf
-from tests.conftest import server
-
-
-def test_get_udf(sample_1: Sample):
-    # GIVEN a sample with a udf "Sequencing Analysis"
-    server("flat_tests")
-    sample_1.udf["Sequencing Analysis"] = "TESTAPPTAG"
-
-    # WHEN getting the apptag for that sample
-    result = get_udf(sample_1, "Sequencing Analysis")
-
-    # THEN the apptag should be returned
-    assert result == "TESTAPPTAG"
-
-
-def test_get_udf_missing_udf(sample_1: Sample):
-    # GIVEN a sample with a missing udf "Sequencing Analysis"
-    assert sample_1.udf.get("Sequencing Analysis") is None
-
-    # WHEN getting the apptag for that sample
-    with pytest.raises(MissingUDFsError) as error_message:
-        get_udf(sample_1, "TESTAPPTAG")
-
-    # THEN the correct exception should be raised
-    assert (
-        f"UDF Sequencing Analysis not found on sample {sample_1.id}"
-        in error_message.value.message
-    )
+# import pytest
+# from genologics.entities import Sample
+#
+# from cg_lims.exceptions import MissingUDFsError
+# from cg_lims.get.udfs import get_udf
+# from tests.conftest import server
+#
+#
+# def test_get_udf(sample_1: Sample):
+#     # GIVEN a sample with a udf "Sequencing Analysis"
+#     server("flat_tests")
+#     sample_1.udf["Sequencing Analysis"] = "TESTAPPTAG"
+#
+#     # WHEN getting the apptag for that sample
+#     result = get_udf(sample_1, "Sequencing Analysis")
+#
+#     # THEN the apptag should be returned
+#     assert result == "TESTAPPTAG"
+#
+#
+# def test_get_udf_missing_udf(sample_1: Sample):
+#     # GIVEN a sample with a missing udf "Sequencing Analysis"
+#     assert sample_1.udf.get("Sequencing Analysis") is None
+#
+#     # WHEN getting the apptag for that sample
+#     with pytest.raises(MissingUDFsError) as error_message:
+#         get_udf(sample_1, "TESTAPPTAG")
+#
+#     # THEN the correct exception should be raised
+#     assert (
+#         f"UDF Sequencing Analysis not found on sample {sample_1.id}"
+#         in error_message.value.message
+#     )

--- a/tests/get/test_udfs.py
+++ b/tests/get/test_udfs.py
@@ -2,30 +2,30 @@ import pytest
 from genologics.entities import Sample
 
 from cg_lims.exceptions import MissingUDFsError
-from cg_lims.get.fields import get_app_tag
+from cg_lims.get.udfs import get_udf
 from tests.conftest import server
 
 server("flat_tests")
 
 
-def test_get_app_tag(sample_1: Sample):
+def test_get_udf(sample_1: Sample):
     # GIVEN a sample with a udf "Sequencing Analysis"
     sample_1.udf["Sequencing Analysis"] = "TESTAPPTAG"
 
     # WHEN getting the apptag for that sample
-    result = get_app_tag(sample_1)
+    result = get_udf(sample_1, "Sequencing Analysis")
 
     # THEN the apptag should be returned
     assert result == "TESTAPPTAG"
 
 
-def test_get_app_tag_missing_udf(sample_1: Sample):
+def test_get_udf_missing_udf(sample_1: Sample):
     # GIVEN a sample with a missing udf "Sequencing Analysis"
     assert sample_1.udf.get("Sequencing Analysis") is None
 
     # WHEN getting the apptag for that sample
     with pytest.raises(MissingUDFsError) as error_message:
-        get_app_tag(sample_1)
+        get_udf(sample_1, "TESTAPPTAG")
 
     # THEN the correct exception should be raised
     assert (

--- a/tests/get/test_udfs.py
+++ b/tests/get/test_udfs.py
@@ -8,7 +8,7 @@ from tests.conftest import server
 
 def test_get_udf(sample_1: Sample):
     # GIVEN a sample with a udf "Sequencing Analysis"
-    server("flat_tests")
+    # server("flat_tests")
     sample_1.udf["Sequencing Analysis"] = "TESTAPPTAG"
 
     # WHEN getting the apptag for that sample

--- a/tests/get/test_udfs.py
+++ b/tests/get/test_udfs.py
@@ -6,6 +6,7 @@
 # from tests.conftest import server
 #
 #
+#
 # def test_get_udf(sample_1: Sample):
 #     # GIVEN a sample with a udf "Sequencing Analysis"
 #     server("flat_tests")

--- a/tests/get/test_udfs.py
+++ b/tests/get/test_udfs.py
@@ -20,11 +20,12 @@ def test_get_udf(sample_1: Sample):
 
 def test_get_udf_missing_udf(sample_1: Sample):
     # GIVEN a sample with a missing udf "Sequencing Analysis"
+    server("flat_tests")
     assert sample_1.udf.get("Sequencing Analysis") is None
 
     # WHEN getting the apptag for that sample
     with pytest.raises(MissingUDFsError) as error_message:
-        get_udf(sample_1, "TESTAPPTAG")
+        get_udf(sample_1, "Sequencing Analysis")
 
     # THEN the correct exception should be raised
     assert (

--- a/tests/get/test_udfs.py
+++ b/tests/get/test_udfs.py
@@ -1,34 +1,33 @@
-# import pytest
-# from genologics.entities import Sample
-#
-# from cg_lims.exceptions import MissingUDFsError
-# from cg_lims.get.udfs import get_udf
-# from tests.conftest import server
-#
-#
-#
-# def test_get_udf(sample_1: Sample):
-#     # GIVEN a sample with a udf "Sequencing Analysis"
-#     server("flat_tests")
-#     sample_1.udf["Sequencing Analysis"] = "TESTAPPTAG"
-#
-#     # WHEN getting the apptag for that sample
-#     result = get_udf(sample_1, "Sequencing Analysis")
-#
-#     # THEN the apptag should be returned
-#     assert result == "TESTAPPTAG"
-#
-#
-# def test_get_udf_missing_udf(sample_1: Sample):
-#     # GIVEN a sample with a missing udf "Sequencing Analysis"
-#     assert sample_1.udf.get("Sequencing Analysis") is None
-#
-#     # WHEN getting the apptag for that sample
-#     with pytest.raises(MissingUDFsError) as error_message:
-#         get_udf(sample_1, "TESTAPPTAG")
-#
-#     # THEN the correct exception should be raised
-#     assert (
-#         f"UDF Sequencing Analysis not found on sample {sample_1.id}"
-#         in error_message.value.message
-#     )
+import pytest
+from genologics.entities import Sample
+
+from cg_lims.exceptions import MissingUDFsError
+from cg_lims.get.udfs import get_udf
+from tests.conftest import server
+
+
+def test_get_udf(sample_1: Sample):
+    # GIVEN a sample with a udf "Sequencing Analysis"
+    server("flat_tests")
+    sample_1.udf["Sequencing Analysis"] = "TESTAPPTAG"
+
+    # WHEN getting the apptag for that sample
+    result = get_udf(sample_1, "Sequencing Analysis")
+
+    # THEN the apptag should be returned
+    assert result == "TESTAPPTAG"
+
+
+def test_get_udf_missing_udf(sample_1: Sample):
+    # GIVEN a sample with a missing udf "Sequencing Analysis"
+    assert sample_1.udf.get("Sequencing Analysis") is None
+
+    # WHEN getting the apptag for that sample
+    with pytest.raises(MissingUDFsError) as error_message:
+        get_udf(sample_1, "TESTAPPTAG")
+
+    # THEN the correct exception should be raised
+    assert (
+        f"UDF Sequencing Analysis not found on sample {sample_1.id}"
+        in error_message.value.message
+    )

--- a/tests/get/test_udfs.py
+++ b/tests/get/test_udfs.py
@@ -8,7 +8,7 @@ from tests.conftest import server
 
 def test_get_udf(sample_1: Sample):
     # GIVEN a sample with a udf "Sequencing Analysis"
-    # server("flat_tests")
+    server("flat_tests")
     sample_1.udf["Sequencing Analysis"] = "TESTAPPTAG"
 
     # WHEN getting the apptag for that sample


### PR DESCRIPTION
### Added

EPP for setting the target amount of reads in the sample udf "Missing Reads (M)", in the relevant reception control steps.

TC1: set missing reads, some samples are missing the "Sequencing Analysis" udf.
TC2: set missing reads, no samples are missing the "Sequencing Analysis" udf.




**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [x] Code approved by @mayabrandi 
- [x] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [x] **MINOR** - when you add functionality in a backwards compatible manner



