### PR TITLE
add subtract volume option to calculate_amount_ng.py

### DIFF
--- a/cg_lims/EPPs/udf/calculate/calculate_amount_ng.py
+++ b/cg_lims/EPPs/udf/calculate/calculate_amount_ng.py
@@ -14,7 +14,7 @@ LOG = logging.getLogger(__name__)
 @options.concentration_udf_option()
 @options.amount_udf_option()
 @options.volume_udf_option()
-@click.option("--subtract-volume", type=click.Choice(["0", "3"]), default="3")
+@options.subtract_volume_option()
 @click.pass_context
 def calculate_amount_ng(
     ctx: click.Context,

--- a/cg_lims/EPPs/udf/calculate/calculate_amount_ng.py
+++ b/cg_lims/EPPs/udf/calculate/calculate_amount_ng.py
@@ -3,10 +3,9 @@ import sys
 
 import click
 
+from cg_lims import options
 from cg_lims.exceptions import LimsError, MissingUDFsError
 from cg_lims.get.artifacts import get_qc_output_artifacts
-from cg_lims.get.samples import get_one_sample_from_artifact
-from cg_lims import options
 
 LOG = logging.getLogger(__name__)
 
@@ -15,12 +14,18 @@ LOG = logging.getLogger(__name__)
 @options.concentration_udf_option()
 @options.amount_udf_option()
 @options.volume_udf_option()
+@click.option("--subtract-volume", type=click.Choice(["0", "3"]), default="3")
 @click.pass_context
 def calculate_amount_ng(
-    ctx: click.Context, amount_udf: str, volume_udf: str, concentration_udf: str
+    ctx: click.Context,
+    amount_udf: str,
+    volume_udf: str,
+    concentration_udf: str,
+    subtract_volume: str,
 ):
-    """Calculates and auto-fills the quantities of DNA in sample from concentration and volume measurements. 
-    The volume is subtracted by 3 in the calculations. This is beacause the lab uses 3 ul in the initial qc measurements."""
+    """Calculates and auto-fills the quantities of DNA in sample from concentration and volume
+    measurements. The volume is subtracted by either 0 or 3 in the calculations. This is
+    because the lab uses 0 or 3 ul in the initial qc measurements."""
 
     LOG.info(f"Running {ctx.command_path} with params: {ctx.params}")
 
@@ -39,11 +44,12 @@ def calculate_amount_ng(
                 artifacts_with_missing_udf.append(artifact.id)
                 continue
 
-            artifact.udf[amount_udf] = conc * (vol - 3)
+            artifact.udf[amount_udf] = conc * (vol - int(subtract_volume))
             artifact.put()
         if missing_udfs_count:
             raise MissingUDFsError(
-                f"Udf missing for {missing_udfs_count} artifact(s): {','.join(artifacts_with_missing_udf)}."
+                f"Udf missing for {missing_udfs_count} artifact(s): "
+                f"{','.join(artifacts_with_missing_udf)}. "
             )
         message = "Amounts have been calculated for all artifacts."
         LOG.info(message)

--- a/cg_lims/options.py
+++ b/cg_lims/options.py
@@ -206,11 +206,15 @@ def file_suffix(help: str = "Define file name suffix") -> click.option:
     return click.option("--suffix", required=False, default="", help=help)
 
 
-def amount_udf_option(help: str = "String of UDF used to get amount value") -> click.option:
+def amount_udf_option(
+    help: str = "String of UDF used to get amount value",
+) -> click.option:
     return click.option("--amount-udf", required=True, help=help)
 
 
-def volume_udf_option(help: str = "String of UDF used to get volume value") -> click.option:
+def volume_udf_option(
+    help: str = "String of UDF used to get volume value",
+) -> click.option:
     return click.option("--volume-udf", required=True, help=help)
 
 
@@ -222,3 +226,11 @@ def concentration_udf_option(
 
 def prep(help: str = "Prep type") -> click.option:
     return click.option("--prep-type", required=True, help=help)
+
+
+def subtract_volume_option(
+    help: str = "Subtracts volume taken from samples in QC checks",
+) -> click.option:
+    return click.option(
+        "--subtract-volume", type=click.Choice(["0", "3"]), default="3", help=help
+    )


### PR DESCRIPTION
### Changed
Moved hardcoded volume of 3 ul to CLI option for calculate_amount_ng.py

Possible choices for new option: `--subtract-volume`: 0 or 3. Default is `3` so that existing automation CLI commands don't need to be updated.

This script should also be applied to the following (see https://github.com/Clinical-Genomics/cg_lims/issues/116):

### Protocol: Initial QC Microbial v3 step CG002 - Quantit QC (DNA). Button: 2. Calculate Amount

current CLI command:
 ```bash -c "/home/glsai/miniconda3/envs/epp_master/bin/calculate_amount.py -p {processLuid}"```

new CLI command:
```bash -c -l "conda activate cg_lims &&  lims -c /home/glsai/.genologics.yaml epps -l {compoundOutputFileLuid0} -p {processLuid}  udf calculate calculate-amount-ng --concentration-udf 'Concentration' --amount-udf 'Amount (ng)' --volume-udf 'Volume (ul)'" --subtract-volume <3|0>```


### Protocol: Library validation QC wgs v3. Step CG002 - Qubit QC (Library Validation) Button: Prehyb QC - Calc Amount and Assign QC Flagg

current CLI command:
```bash -c "/home/glsai/miniconda3/envs/epp_master/bin/calculate_amount.py -p {processLuid} && /home/glsai/miniconda3/envs/epp_master/bin/set_qc.py -p {processLuid} -l {compoundOutputFileLuid3} -t 'Minimum required amount (ng)' -u 'Amount (ng)'"```

new CLI command:
```bash -c -l "conda activate cg_lims &&  lims -c /home/glsai/.genologics.yaml epps -l {compoundOutputFileLuid0} -p {processLuid}  udf calculate calculate-amount-ng --concentration-udf 'Concentration' --amount-udf 'Amount (ng)' --volume-udf 'Volume (ul)'" --subtract-volume <3|0> && /home/glsai/miniconda3/envs/epp_master/bin/set_qc.py -p {processLuid} -l {compoundOutputFileLuid3} -t 'Minimum required amount (ng)' -u 'Amount (ng)'"```

**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [x] Tests executed on stage by @barrystokman
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [x] **MINOR** - when you add functionality in a backwards compatible manner



