### PR TITLE
Move Aggregate QC and Copy Fields EPP

### DIFF
--- a/cg_lims/EPPs/udf/copy/aggregate_qc_and_copy_fields.py
+++ b/cg_lims/EPPs/udf/copy/aggregate_qc_and_copy_fields.py
@@ -2,48 +2,30 @@ import logging
 import sys
 import click
 
-from typing import List, Tuple, Optional
+from typing import List, Tuple
 
-from genologics.entities import Artifact, Process
-from genologics.lims import Lims
+from genologics.entities import Process
 
-from cg_lims.get.artifacts import get_artifacts, get_qc_output_artifacts, get_latest_artifact
-from cg_lims.get.udfs import get_process_udf
-from cg_lims.EPPs.udf.copy.artifact_to_artifact import copy_udfs_to_all_artifacts
-from cg_lims.set.udfs import copy_artifact_to_artifact
-from cg_lims.exceptions import LimsError, MissingUDFsError
+from cg_lims.get.artifacts import get_artifacts
+from cg_lims.set.udfs import copy_udfs_to_artifacts
+from cg_lims.exceptions import LimsError
 
 LOG = logging.getLogger(__name__)
 
 
 def get_source_udf(process: Process) -> List[Tuple[str, str]]:
-    copy_task_1_step = get_process_udf(process, "Copy task 1 - Source Step")
-    copy_task_2_step = get_process_udf(process, "Copy task 2 - Source Step")
-    copy_task_1_field = get_process_udf(process, "Copy task 1 - Source Field")
-    copy_task_2_field = get_process_udf(process, "Copy task 2 - Source Field")
-    source_udfs = [(copy_task_1_step, copy_task_1_field), (copy_task_2_step, copy_task_2_field)]
+    copy_tasks = {}
+    source_udfs = []
+    for udf, value in process.udf.items():
+        if 'Copy task' in udf:
+            task_number, copy_type = udf.split('-')
+            if task_number.strip() in copy_tasks.keys():
+                copy_tasks[task_number.strip()][copy_type.strip()] = value
+            else:
+                copy_tasks[task_number.strip()] = {copy_type.strip(): value}
+    for copy_task in copy_tasks:
+        source_udfs.append((copy_tasks[copy_task]['Source Step'], copy_tasks[copy_task]['Source Field']))
     return source_udfs
-
-
-def get_latest_processes(artifact: Artifact, process_type: str, lims: Lims) -> Process:
-    """Get the lastest process of a specific type given an artifact"""
-    processes = lims.get_processes(inputartifactlimsid=artifact.id)
-    latest_process = ''
-    for process in processes:
-        current_process_type = process.type.name
-        if current_process_type == process_type:
-            if latest_process == '':
-                latest_process = process
-            elif latest_process.date_run < process.date_run:
-                latest_process = process
-    return latest_process
-
-
-def copy_udfs(artifacts: List[Artifact], source_udfs: List[Tuple[str, str]], lims: Lims) -> None:
-    for artifact in artifacts:
-        source_processes = []
-        for source
-        = get_latest_processes(artifact=artifact, process_type: str, lims=lims)
 
 
 @click.command()
@@ -57,19 +39,16 @@ def aggregate_qc_and_copy_fields(ctx) -> None:
     lims = ctx.obj["lims"]
 
     try:
-        artifacts = get_artifacts(process=process, input=True) #check up
-        print(artifacts)
+        artifacts = get_artifacts(process=process, input=True)
         source_udfs = get_source_udf(process)
-        latest_process = get_latest_processes(artifact=artifacts[0], process_type=source_udfs[0][0], lims=lims)
-        print(latest_process)
         for task in source_udfs:
-            print(task)
-            copy_udfs_to_all_artifacts(artifacts=artifacts,
-                                       process_types=[task[0]],
-                                       lims=lims,
-                                       udfs=[(task[1], task[1])],
-                                       qc_flag=True,
-                                       )
+            copy_udfs_to_artifacts(artifacts=artifacts,
+                                   process_types=[task[0]],
+                                   lims=lims,
+                                   udfs=[(task[1], task[1])],
+                                   qc_flag=True,
+                                   measurement=True,
+                                   )
 
         message = "UDFs were successfully copied!"
         LOG.info(message)

--- a/cg_lims/EPPs/udf/copy/aggregate_qc_and_copy_fields.py
+++ b/cg_lims/EPPs/udf/copy/aggregate_qc_and_copy_fields.py
@@ -9,7 +9,7 @@ from genologics.lims import Lims
 
 from cg_lims.get.artifacts import get_artifacts
 from cg_lims.set.udfs import copy_udfs_to_artifacts
-from cg_lims.exceptions import LimsError
+from cg_lims.exceptions import LimsError, MissingUDFsError
 
 LOG = logging.getLogger(__name__)
 
@@ -26,6 +26,8 @@ def get_source_udf(process: Process) -> List[Tuple[str, str]]:
                 copy_tasks[task_number.strip()] = {copy_type.strip(): value}
     for copy_task in copy_tasks:
         source_udfs.append((copy_tasks[copy_task]['Source Step'], copy_tasks[copy_task]['Source Field']))
+    if not source_udfs:
+        raise MissingUDFsError(f"Copy task udf missing for process {process.id}.")
     return source_udfs
 
 

--- a/cg_lims/EPPs/udf/copy/aggregate_qc_and_copy_fields.py
+++ b/cg_lims/EPPs/udf/copy/aggregate_qc_and_copy_fields.py
@@ -1,0 +1,79 @@
+import logging
+import sys
+import click
+
+from typing import List, Tuple, Optional
+
+from genologics.entities import Artifact, Process
+from genologics.lims import Lims
+
+from cg_lims.get.artifacts import get_artifacts, get_qc_output_artifacts, get_latest_artifact
+from cg_lims.get.udfs import get_process_udf
+from cg_lims.EPPs.udf.copy.artifact_to_artifact import copy_udfs_to_all_artifacts
+from cg_lims.set.udfs import copy_artifact_to_artifact
+from cg_lims.exceptions import LimsError, MissingUDFsError
+
+LOG = logging.getLogger(__name__)
+
+
+def get_source_udf(process: Process) -> List[Tuple[str, str]]:
+    copy_task_1_step = get_process_udf(process, "Copy task 1 - Source Step")
+    copy_task_2_step = get_process_udf(process, "Copy task 2 - Source Step")
+    copy_task_1_field = get_process_udf(process, "Copy task 1 - Source Field")
+    copy_task_2_field = get_process_udf(process, "Copy task 2 - Source Field")
+    source_udfs = [(copy_task_1_step, copy_task_1_field), (copy_task_2_step, copy_task_2_field)]
+    return source_udfs
+
+
+def get_latest_processes(artifact: Artifact, process_type: str, lims: Lims) -> Process:
+    """Get the lastest process of a specific type given an artifact"""
+    processes = lims.get_processes(inputartifactlimsid=artifact.id)
+    latest_process = ''
+    for process in processes:
+        current_process_type = process.type.name
+        if current_process_type == process_type:
+            if latest_process == '':
+                latest_process = process
+            elif latest_process.date_run < process.date_run:
+                latest_process = process
+    return latest_process
+
+
+def copy_udfs(artifacts: List[Artifact], source_udfs: List[Tuple[str, str]], lims: Lims) -> None:
+    for artifact in artifacts:
+        source_processes = []
+        for source
+        = get_latest_processes(artifact=artifact, process_type: str, lims=lims)
+
+
+@click.command()
+@click.pass_context
+def aggregate_qc_and_copy_fields(ctx) -> None:
+    """Script to calculate and apply Average Size (bp) to a set of samples
+    given a subset of their real size lengths. NTC samples are ignored in the calculations."""
+
+    LOG.info(f"Running {ctx.command_path} with params: {ctx.params}")
+    process = ctx.obj["process"]
+    lims = ctx.obj["lims"]
+
+    try:
+        artifacts = get_artifacts(process=process, input=True) #check up
+        print(artifacts)
+        source_udfs = get_source_udf(process)
+        latest_process = get_latest_processes(artifact=artifacts[0], process_type=source_udfs[0][0], lims=lims)
+        print(latest_process)
+        for task in source_udfs:
+            print(task)
+            copy_udfs_to_all_artifacts(artifacts=artifacts,
+                                       process_types=[task[0]],
+                                       lims=lims,
+                                       udfs=[(task[1], task[1])],
+                                       qc_flag=True,
+                                       )
+
+        message = "UDFs were successfully copied!"
+        LOG.info(message)
+        click.echo(message)
+    except LimsError as e:
+        LOG.error(e.message)
+        sys.exit(e.message)

--- a/cg_lims/EPPs/udf/copy/base.py
+++ b/cg_lims/EPPs/udf/copy/base.py
@@ -9,6 +9,7 @@ from cg_lims.EPPs.udf.copy.process_to_sample import process_to_sample
 from cg_lims.EPPs.udf.copy.reads_to_sequence import reads_to_sequence
 from cg_lims.EPPs.udf.copy.artifact_to_artifact import artifact_to_artifact
 from cg_lims.EPPs.udf.copy.process_to_artifact import process_to_artifact
+from cg_lims.EPPs.udf.copy.aggregate_qc_and_copy_fields import aggregate_qc_and_copy_fields
 
 
 @click.group(invoke_without_command=True)
@@ -24,3 +25,4 @@ copy.add_command(process_to_sample)
 copy.add_command(reads_to_sequence)
 copy.add_command(artifact_to_artifact)
 copy.add_command(process_to_artifact)
+copy.add_command(aggregate_qc_and_copy_fields)

--- a/cg_lims/get/artifacts.py
+++ b/cg_lims/get/artifacts.py
@@ -94,7 +94,7 @@ def get_latest_artifact(
         )
         lims_artifacts = []
         for artifact in all_lims_artifacts:
-            if len(artifact.samples) == 1:
+            if not artifact.files:
                 lims_artifacts.append(artifact)
     else:
         lims_artifacts = lims.get_artifacts(

--- a/cg_lims/get/artifacts.py
+++ b/cg_lims/get/artifacts.py
@@ -77,8 +77,8 @@ def get_latest_artifact(
 ) -> Artifact:
     """Getting the most recently generated artifact by process_types and sample_id.
 
-    Searching for all artifacts (Analytes) associated with <sample_id> that
-    were produced by <process_types>.
+    Searching for either all artifacts (Analytes), or measurements (ResultFiles),
+    associated with <sample_id> that were produced by <process_types>.
 
     Returning the artifact with latest parent_process.date_run.
     If there are many such artifacts only one will be returned."""
@@ -94,7 +94,8 @@ def get_latest_artifact(
         )
         lims_artifacts = []
         for artifact in all_lims_artifacts:
-            if not artifact.files:
+            output = [io[1] for io in artifact.parent_process.input_output_maps if io[1]['limsid'] == artifact.id]
+            if output[0]["output-generation-type"] == "PerInput":
                 lims_artifacts.append(artifact)
     else:
         lims_artifacts = lims.get_artifacts(

--- a/cg_lims/get/artifacts.py
+++ b/cg_lims/get/artifacts.py
@@ -69,7 +69,11 @@ def filter_artifacts(artifacts: List[Artifact], udf: str, value) -> List[Artifac
 
 
 def get_latest_artifact(
-    lims: Lims, sample_id: str, process_types: Optional[List[str]], sample_artifact: bool = False
+    lims: Lims,
+    sample_id: str,
+    process_types: Optional[List[str]],
+    sample_artifact: bool = False,
+    measurement: Optional[bool] = False,
 ) -> Artifact:
     """Getting the most recently generated artifact by process_types and sample_id.
 
@@ -82,11 +86,22 @@ def get_latest_artifact(
     if sample_artifact and not process_types:
         return get_sample_artifact(lims=lims, sample=Sample(lims, sample_id))
 
-    lims_artifacts = lims.get_artifacts(
-        samplelimsid=sample_id,
-        type="Analyte",
-        process_type=process_types,
-    )
+    if measurement:
+        all_lims_artifacts = lims.get_artifacts(
+            samplelimsid=sample_id,
+            type="ResultFile",
+            process_type=process_types,
+        )
+        lims_artifacts = []
+        for artifact in all_lims_artifacts:
+            if len(artifact.samples) == 1:
+                lims_artifacts.append(artifact)
+    else:
+        lims_artifacts = lims.get_artifacts(
+            samplelimsid=sample_id,
+            type="Analyte",
+            process_type=process_types,
+        )
 
     if sample_artifact and not lims_artifacts:
         return get_sample_artifact(lims=lims, sample=Sample(lims, sample_id))

--- a/cg_lims/get/udfs.py
+++ b/cg_lims/get/udfs.py
@@ -1,6 +1,6 @@
 from datetime import date
 from typing import Optional
-from genologics.entities import Sample
+from genologics.entities import Sample, Process
 from genologics.lims import Lims
 
 from cg_lims.exceptions import MissingUDFsError
@@ -30,3 +30,11 @@ def get_udf(sample: Sample, udf: str) -> str:
         return sample.udf[udf]
     except Exception:
         raise MissingUDFsError(f"UDF {udf} not found on sample {sample.id}!")
+
+
+def get_process_udf(process: Process, udf: str) -> str:
+    """Returns the value of a udf on a process"""
+    try:
+        return process.udf[udf]
+    except Exception:
+        raise MissingUDFsError(f"UDF {udf} not found on process {process.id}!")

--- a/cg_lims/set/udfs.py
+++ b/cg_lims/set/udfs.py
@@ -73,8 +73,9 @@ def copy_udfs_to_artifacts(
     failed_artifacts = 0
     for destination_artifact in artifacts:
         try:
-            if destination_artifact.qc_flag == "FAILED":
-                qc_flag = False
+            qc_flag_copy = False
+            if qc_flag is True and destination_artifact.qc_flag != "FAILED":
+                qc_flag_copy = True
             sample = destination_artifact.samples[0]
             source_artifact = get_latest_artifact(
                 lims=lims,
@@ -87,7 +88,7 @@ def copy_udfs_to_artifacts(
                 destination_artifact=destination_artifact,
                 source_artifact=source_artifact,
                 artifact_udfs=udfs,
-                qc_flag=qc_flag,
+                qc_flag=qc_flag_copy,
             )
         except:
             failed_artifacts += 1

--- a/cg_lims/set/udfs.py
+++ b/cg_lims/set/udfs.py
@@ -73,6 +73,8 @@ def copy_udfs_to_artifacts(
     failed_artifacts = 0
     for destination_artifact in artifacts:
         try:
+            if destination_artifact.qc_flag == "FAILED":
+                qc_flag = False
             sample = destination_artifact.samples[0]
             source_artifact = get_latest_artifact(
                 lims=lims,

--- a/tests/EPPs/udf/copy/test_aggregate_qc_and_copy_fields.py
+++ b/tests/EPPs/udf/copy/test_aggregate_qc_and_copy_fields.py
@@ -1,0 +1,170 @@
+import pytest
+from genologics.entities import Artifact, Process
+
+from cg_lims.EPPs.udf.copy.aggregate_qc_and_copy_fields import get_source_udf, copy_source_udfs_to_artifacts
+from cg_lims.exceptions import MissingUDFsError
+from tests.conftest import server
+
+
+def test_get_source_udf_3_tasks(lims):
+    # GIVEN a process with 3 copy task udfs:
+    # Copy task 1 - Source Field -> Size (bp)
+    # Copy task 1 - Source Step -> Tapestation QC TWIST v2
+    # Copy task 2 - Source Field -> Concentration
+    # Copy task 2 - Source Step -> Qubit QC (Library Validation) v2
+    # Copy task 3 - Source Field -> Amount (ng)
+    # Copy task 3 - Source Step -> Qubit QC (Library Validation) v2
+    server("twist_prep")
+    process = Process(lims, id="24-240289")
+
+    # WHEN running get_source_udf
+    source_udfs = get_source_udf(process=process)
+
+    # THEN the correct source udfs are collected in a list of tuples
+    correct_source_udfs = [
+        ("Tapestation QC TWIST v2", "Size (bp)"),
+        ("Qubit QC (Library Validation) v2", "Concentration"),
+        ("Qubit QC (Library Validation) v2", "Amount (ng)")
+    ]
+    assert source_udfs == correct_source_udfs
+
+
+def test_get_source_udf_2_tasks(lims):
+    # GIVEN a process with 2 copy task udfs:
+    # Copy task 1 - Source Field -> Concentration (nM)
+    # Copy task 1 - Source Step -> CG002 - qPCR QC (Library Validation)
+    # Copy task 2 - Source Field -> Size (bp)
+    # Copy task 2 - Source Step -> CG002 - qPCR QC (Library Validation)
+    server("wgs_prep")
+    process = Process(lims, id="24-240276")
+
+    # WHEN running get_source_udf
+    source_udfs = get_source_udf(process=process)
+
+    # THEN the correct source udfs are collected in a list of tuples
+    correct_source_udfs = [
+        ("CG002 - qPCR QC (Library Validation)", "Concentration (nM)"),
+        ("CG002 - qPCR QC (Library Validation)", "Size (bp)")
+    ]
+    assert source_udfs == correct_source_udfs
+
+
+def test_get_source_udf_no_tasks(lims):
+    # GIVEN a process with no copy task udfs
+    server("wgs_prep")
+    process = Process(lims, id="24-240274")
+
+    # WHEN running get_source_udf
+    # THEN MissingUDFsError is raised
+    with pytest.raises(MissingUDFsError) as error_message:
+        source_udfs = get_source_udf(process=process)
+
+
+def test_copy_source_udfs_to_artifacts_pools(lims):
+    # GIVEN a process with 3 copy task udfs:
+    # Copy task 1 - Source Field -> Size (bp)
+    # Copy task 1 - Source Step -> Tapestation QC TWIST v2
+    # Copy task 2 - Source Field -> Concentration
+    # Copy task 2 - Source Step -> Qubit QC (Library Validation) v2
+    # Copy task 3 - Source Field -> Amount (ng)
+    # Copy task 3 - Source Step -> Qubit QC (Library Validation) v2
+    #
+    # And 2 artifacts which have gone through the necessary QC steps.
+
+    server("aggregate_qc")
+    process = Process(lims, id="24-306116")
+    artifact_1 = Artifact(lims, id="2-2392049")
+    artifact_2 = Artifact(lims, id="2-2392301")
+    artifact_2.qc_flag = "UNKNOWN"
+    artifact_2.put()
+
+    # WHEN running copy_source_udfs_to_artifacts
+    copy_source_udfs_to_artifacts(process=process, lims=lims)
+
+    # THEN the correct values has been copied over
+    correct_udfs_1 = {"Size (bp)": 450,
+                      "Concentration": 1.555,
+                      "Amount (ng)": 46.65}
+    correct_udfs_2 = {"Size (bp)": 455,
+                      "Concentration": 1.777,
+                      "Amount (ng)": 53.31}
+    for udf in correct_udfs_1:
+        assert artifact_1.udf[udf] == correct_udfs_1[udf]
+        assert artifact_2.udf[udf] == correct_udfs_2[udf]
+    assert artifact_1.qc_flag == "PASSED"
+    assert artifact_2.qc_flag == "PASSED"
+
+
+def test_copy_source_udfs_to_artifacts(lims):
+    # GIVEN a process with 3 copy task udfs:
+    # Copy task 1 - Source Field -> Size (bp)
+    # Copy task 1 - Source Step -> Tapestation QC TWIST v2
+    # Copy task 2 - Source Field -> Concentration
+    # Copy task 2 - Source Step -> Quantit QC (Library Validation) TWIST v2
+    # Copy task 3 - Source Field -> Amount (ng)
+    # Copy task 3 - Source Step -> Quantit QC (Library Validation) TWIST v2
+    #
+    # And 2 artifacts which have gone through the necessary QC steps.
+
+    server("aggregate_qc")
+    process = Process(lims, id="24-306120")
+    artifact_1 = Artifact(lims, id="2-2406340")
+    artifact_2 = Artifact(lims, id="2-2406348")
+    artifact_2.qc_flag = "UNKNOWN"
+    artifact_2.put()
+
+    # WHEN running copy_source_udfs_to_artifacts
+    copy_source_udfs_to_artifacts(process=process, lims=lims)
+
+    # THEN the correct values has been copied over
+    correct_udfs_1 = {"Size (bp)": 337,
+                      "Concentration": 1.2121,
+                      "Amount (ng)": 36.363}
+    correct_udfs_2 = {"Size (bp)": 288,
+                      "Concentration": 1.8,
+                      "Amount (ng)": 54}
+    for udf in correct_udfs_1:
+        assert artifact_1.udf[udf] == correct_udfs_1[udf]
+        assert artifact_2.udf[udf] == correct_udfs_2[udf]
+    assert artifact_1.qc_flag == "PASSED"
+    assert artifact_2.qc_flag == "PASSED"
+
+
+def test_copy_source_udfs_to_artifacts_qc_fail(lims):
+    # GIVEN a process with 3 copy task udfs:
+    # Copy task 1 - Source Field -> Size (bp)
+    # Copy task 1 - Source Step -> Tapestation QC TWIST v2
+    # Copy task 2 - Source Field -> Concentration
+    # Copy task 2 - Source Step -> Qubit QC (Library Validation) v2
+    # Copy task 3 - Source Field -> Amount (ng)
+    # Copy task 3 - Source Step -> Qubit QC (Library Validation) v2
+    #
+    # And 2 artifacts which have gone through the necessary QC steps,
+    # where one failed in one of the QC steps and the other was set to
+    # failed in the aggregate step.
+
+    server("aggregate_qc")
+    process = Process(lims, id="24-306116")
+    artifact_1 = Artifact(lims, id="2-2392049")
+    artifact_2 = Artifact(lims, id="2-2392301")
+    artifact_2.qc_flag = "FAILED"
+    artifact_2.put()
+    tapestation = Artifact(lims, id="92-2407146")
+    tapestation.qc_flag = "FAILED"
+    tapestation.put()
+
+    # WHEN running copy_source_udfs_to_artifacts
+    copy_source_udfs_to_artifacts(process=process, lims=lims)
+
+    # THEN the correct values has been copied over and both QC flags are set to FAILED
+    correct_udfs_1 = {"Size (bp)": 450,
+                      "Concentration": 1.555,
+                      "Amount (ng)": 46.65}
+    correct_udfs_2 = {"Size (bp)": 455,
+                      "Concentration": 1.777,
+                      "Amount (ng)": 53.31}
+    for udf in correct_udfs_1:
+        assert artifact_1.udf[udf] == correct_udfs_1[udf]
+        assert artifact_2.udf[udf] == correct_udfs_2[udf]
+    assert artifact_1.qc_flag == "FAILED"
+    assert artifact_2.qc_flag == "FAILED"

--- a/tests/fixtures/aggregate_qc/artifacts/2-2392049.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/2-2392049.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049?state=1887755" limsid="2-2392049">
+    <name>tga220307_A1_Exome</name>
+    <type>Analyte</type>
+    <output-type>Analyte</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+    <qc-flag>PASSED</qc-flag>
+    <location>
+        <container uri="http://127.0.0.1:8000/api/v2/containers/27-239469" limsid="27-239469" />
+        <value>A:1</value>
+    </location>
+    <working-flag>true</working-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC7965A63" limsid="ACC7965A63" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A2" limsid="ACC9531A2" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A3" limsid="ACC9531A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A4" limsid="ACC9531A4" />
+    <reagent-label name="C06 IDT_10nt_467 (GAAGGAGCCT-CCTCCATTAT)" />
+    <reagent-label name="B06 IDT_10nt_454 (ATTCTTGCCT-GTGCAGCTAC)" />
+    <reagent-label name="D06 IDT_10nt_480 (AGACGTGTTA-TTACAGTTGG)" />
+    <reagent-label name="E09 IDT_10nt_498 (CGCTTCTCCT-TTGGCTAGGC)" />
+    <udf:field type="Numeric" name="Missing reads Pool (M)">320</udf:field>
+    <workflow-stages>
+        <workflow-stage status="IN_PROGRESS" name="Library Validation QC TWIST v2" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1601/stages/5114" />
+        <workflow-stage status="COMPLETE" name="Define Run Format and Calculate Volumes (Nova Seq)" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1851/stages/6523" />
+        <workflow-stage status="COMPLETE" name="Library Validation QC TWIST (post hyb)" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1851/stages/6522" />
+        <workflow-stage status="IN_PROGRESS" name="Library Validation QC TWIST (post hyb)" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1851/stages/6522" />
+    </workflow-stages>
+    <demux uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049/demux" />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/2-2392301.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/2-2392301.xml
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301?state=1887754" limsid="2-2392301">
+    <name>tga220307_C1_Lymphoid</name>
+    <type>Analyte</type>
+    <output-type>Analyte</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+    <qc-flag>PASSED</qc-flag>
+    <location>
+        <container uri="http://127.0.0.1:8000/api/v2/containers/27-239469" limsid="27-239469" />
+        <value>C:1</value>
+    </location>
+    <working-flag>true</working-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC8254A27" limsid="ACC8254A27" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9500A1" limsid="ACC9500A1" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9500A3" limsid="ACC9500A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A3" limsid="ACC9543A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A5" limsid="ACC9543A5" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A13" limsid="ACC9543A13" />
+    <reagent-label name="E07 IDT_10nt_496 (GTTGCCTGAC-TTGGCAACCG)" />
+    <reagent-label name="A07 IDT_10nt_442 (TTAACCTGCG-CTACTGATGT)" />
+    <reagent-label name="H06 IDT_10nt_534 (GTAATGCGGC-CTTGAATTCG)" />
+    <reagent-label name="E06 IDT_10nt_495 (AATGGTCTAC-CCATAAGAGG)" />
+    <reagent-label name="G09 IDT_10nt_523 (CTCGCATAGA-CTAGATAACG)" />
+    <reagent-label name="B09 IDT_10nt_457 (AATGGACCTT-TATCCAACGA)" />
+    <udf:field type="Numeric" name="Missing reads Pool (M)">240</udf:field>
+    <workflow-stages>
+        <workflow-stage status="IN_PROGRESS" name="Library Validation QC TWIST v2" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1601/stages/5114" />
+        <workflow-stage status="COMPLETE" name="Define Run Format and Calculate Volumes (Nova Seq)" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1851/stages/6523" />
+        <workflow-stage status="COMPLETE" name="Library Validation QC TWIST (post hyb)" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1851/stages/6522" />
+        <workflow-stage status="IN_PROGRESS" name="Library Validation QC TWIST (post hyb)" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1851/stages/6522" />
+    </workflow-stages>
+    <demux uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301/demux" />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/2-2406340.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/2-2406340.xml
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" limsid="2-2406340">
+    <name>KMP-00171T-A09 IDT_10nt_445 (TTGGCACTTA-GTGCGTCGTA)</name>
+    <type>Analyte</type>
+    <output-type>Analyte</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+    <qc-flag>PASSED</qc-flag>
+    <location>
+        <container uri="http://127.0.0.1:8000/api/v2/containers/27-241172" limsid="27-241172" />
+        <value>A:2</value>
+    </location>
+    <working-flag>true</working-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9476A23" limsid="ACC9476A23" />
+    <reagent-label name="A09 IDT_10nt_445 (TTGGCACTTA-GTGCGTCGTA)" />
+    <udf:field type="Numeric" name="Amount taken (ng)">441.1764705882353</udf:field>
+    <udf:field type="Numeric" name="Volume of sample (ul)">8.823529411764707</udf:field>
+    <udf:field type="String" name="Ligation Master Mix">A</udf:field>
+    <udf:field type="String" name="PCR Plate">Plate1</udf:field>
+    <udf:field type="String" name="Output Container Barcode">123-5</udf:field>
+    <workflow-stages>
+        <workflow-stage status="COMPLETE" name="Pool samples for hybridization TWIST" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1951/stages/6859" />
+        <workflow-stage status="COMPLETE" name="Library Validation QC TWIST v2" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1951/stages/6858" />
+        <workflow-stage status="IN_PROGRESS" name="Library Validation QC TWIST v2" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1951/stages/6858" />
+    </workflow-stages>
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/2-2406348.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/2-2406348.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" limsid="2-2406348">
+    <name>MOL694-22-B05 IDT_10nt_453 (CAGCACTACG-CGCCACAGAA)</name>
+    <type>Analyte</type>
+    <output-type>Analyte</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+    <qc-flag>PASSED</qc-flag>
+    <location>
+        <container uri="http://127.0.0.1:8000/api/v2/containers/27-241172" limsid="27-241172" />
+        <value>A:3</value>
+    </location>
+    <working-flag>true</working-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9587A3" limsid="ACC9587A3" />
+    <reagent-label name="B05 IDT_10nt_453 (CAGCACTACG-CGCCACAGAA)" />
+    <udf:field type="Numeric" name="Amount taken (ng)">125</udf:field>
+    <udf:field type="Numeric" name="Volume of sample (ul)">2.5</udf:field>
+    <udf:field type="String" name="Warning">Amount to pool lower than minimum amount.</udf:field>
+    <udf:field type="String" name="Ligation Master Mix">A</udf:field>
+    <udf:field type="String" name="PCR Plate">Plate1</udf:field>
+    <udf:field type="String" name="Output Container Barcode">123-5</udf:field>
+    <workflow-stages>
+        <workflow-stage status="COMPLETE" name="Pool samples for hybridization TWIST" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1951/stages/6859" />
+        <workflow-stage status="COMPLETE" name="Library Validation QC TWIST v2" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1951/stages/6858" />
+        <workflow-stage status="IN_PROGRESS" name="Library Validation QC TWIST v2" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1951/stages/6858" />
+    </workflow-stages>
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407146.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407146.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407146?state=1900008" limsid="92-2407146">
+    <name>Fragment Analyzer tga220307_A1_Exome</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306112" limsid="24-306112" />
+    <qc-flag>PASSED</qc-flag>
+    <location>
+        <container uri="http://127.0.0.1:8000/api/v2/containers/27-241196" limsid="27-241196" />
+        <value>A:1</value>
+    </location>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC7965A63" limsid="ACC7965A63" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A2" limsid="ACC9531A2" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A3" limsid="ACC9531A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A4" limsid="ACC9531A4" />
+    <reagent-label name="C06 IDT_10nt_467 (GAAGGAGCCT-CCTCCATTAT)" />
+    <reagent-label name="B06 IDT_10nt_454 (ATTCTTGCCT-GTGCAGCTAC)" />
+    <reagent-label name="D06 IDT_10nt_480 (AGACGTGTTA-TTACAGTTGG)" />
+    <reagent-label name="E09 IDT_10nt_498 (CGCTTCTCCT-TTGGCTAGGC)" />
+    <udf:field type="Numeric" name="Size (bp)">450</udf:field>
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407147.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407147.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407147?state=1900009" limsid="92-2407147">
+    <name>Fragment Analyzer tga220307_C1_Lymphoid</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306112" limsid="24-306112" />
+    <qc-flag>PASSED</qc-flag>
+    <location>
+        <container uri="http://127.0.0.1:8000/api/v2/containers/27-241196" limsid="27-241196" />
+        <value>C:1</value>
+    </location>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC8254A27" limsid="ACC8254A27" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9500A1" limsid="ACC9500A1" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9500A3" limsid="ACC9500A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A3" limsid="ACC9543A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A5" limsid="ACC9543A5" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A13" limsid="ACC9543A13" />
+    <reagent-label name="E07 IDT_10nt_496 (GTTGCCTGAC-TTGGCAACCG)" />
+    <reagent-label name="A07 IDT_10nt_442 (TTAACCTGCG-CTACTGATGT)" />
+    <reagent-label name="H06 IDT_10nt_534 (GTAATGCGGC-CTTGAATTCG)" />
+    <reagent-label name="E06 IDT_10nt_495 (AATGGTCTAC-CCATAAGAGG)" />
+    <reagent-label name="G09 IDT_10nt_523 (CTCGCATAGA-CTAGATAACG)" />
+    <reagent-label name="B09 IDT_10nt_457 (AATGGACCTT-TATCCAACGA)" />
+    <udf:field type="Numeric" name="Size (bp)">455</udf:field>
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407148.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407148.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407148?state=1900005" limsid="92-2407148">
+    <name>EPP Log</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306112" limsid="24-306112" />
+    <qc-flag>UNKNOWN</qc-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC7965A63" limsid="ACC7965A63" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC8254A27" limsid="ACC8254A27" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9500A1" limsid="ACC9500A1" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9500A3" limsid="ACC9500A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A2" limsid="ACC9531A2" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A3" limsid="ACC9531A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A4" limsid="ACC9531A4" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A3" limsid="ACC9543A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A5" limsid="ACC9543A5" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A13" limsid="ACC9543A13" />
+    <reagent-label name="C06 IDT_10nt_467 (GAAGGAGCCT-CCTCCATTAT)" />
+    <reagent-label name="B06 IDT_10nt_454 (ATTCTTGCCT-GTGCAGCTAC)" />
+    <reagent-label name="E07 IDT_10nt_496 (GTTGCCTGAC-TTGGCAACCG)" />
+    <reagent-label name="A07 IDT_10nt_442 (TTAACCTGCG-CTACTGATGT)" />
+    <reagent-label name="H06 IDT_10nt_534 (GTAATGCGGC-CTTGAATTCG)" />
+    <reagent-label name="E06 IDT_10nt_495 (AATGGTCTAC-CCATAAGAGG)" />
+    <reagent-label name="D06 IDT_10nt_480 (AGACGTGTTA-TTACAGTTGG)" />
+    <reagent-label name="G09 IDT_10nt_523 (CTCGCATAGA-CTAGATAACG)" />
+    <reagent-label name="E09 IDT_10nt_498 (CGCTTCTCCT-TTGGCTAGGC)" />
+    <reagent-label name="B09 IDT_10nt_457 (AATGGACCTT-TATCCAACGA)" />
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407149.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407149.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407149?state=1900006" limsid="92-2407149">
+    <name>Tapestation PDF Report</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306112" limsid="24-306112" />
+    <qc-flag>UNKNOWN</qc-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC7965A63" limsid="ACC7965A63" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC8254A27" limsid="ACC8254A27" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9500A1" limsid="ACC9500A1" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9500A3" limsid="ACC9500A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A2" limsid="ACC9531A2" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A3" limsid="ACC9531A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A4" limsid="ACC9531A4" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A3" limsid="ACC9543A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A5" limsid="ACC9543A5" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A13" limsid="ACC9543A13" />
+    <reagent-label name="C06 IDT_10nt_467 (GAAGGAGCCT-CCTCCATTAT)" />
+    <reagent-label name="B06 IDT_10nt_454 (ATTCTTGCCT-GTGCAGCTAC)" />
+    <reagent-label name="E07 IDT_10nt_496 (GTTGCCTGAC-TTGGCAACCG)" />
+    <reagent-label name="A07 IDT_10nt_442 (TTAACCTGCG-CTACTGATGT)" />
+    <reagent-label name="H06 IDT_10nt_534 (GTAATGCGGC-CTTGAATTCG)" />
+    <reagent-label name="E06 IDT_10nt_495 (AATGGTCTAC-CCATAAGAGG)" />
+    <reagent-label name="D06 IDT_10nt_480 (AGACGTGTTA-TTACAGTTGG)" />
+    <reagent-label name="G09 IDT_10nt_523 (CTCGCATAGA-CTAGATAACG)" />
+    <reagent-label name="E09 IDT_10nt_498 (CGCTTCTCCT-TTGGCTAGGC)" />
+    <reagent-label name="B09 IDT_10nt_457 (AATGGACCTT-TATCCAACGA)" />
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407150.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407150.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407150?state=1900007" limsid="92-2407150">
+    <name>Tapestation CSV</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306112" limsid="24-306112" />
+    <qc-flag>UNKNOWN</qc-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC7965A63" limsid="ACC7965A63" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC8254A27" limsid="ACC8254A27" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9500A1" limsid="ACC9500A1" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9500A3" limsid="ACC9500A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A2" limsid="ACC9531A2" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A3" limsid="ACC9531A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A4" limsid="ACC9531A4" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A3" limsid="ACC9543A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A5" limsid="ACC9543A5" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A13" limsid="ACC9543A13" />
+    <reagent-label name="C06 IDT_10nt_467 (GAAGGAGCCT-CCTCCATTAT)" />
+    <reagent-label name="B06 IDT_10nt_454 (ATTCTTGCCT-GTGCAGCTAC)" />
+    <reagent-label name="E07 IDT_10nt_496 (GTTGCCTGAC-TTGGCAACCG)" />
+    <reagent-label name="A07 IDT_10nt_442 (TTAACCTGCG-CTACTGATGT)" />
+    <reagent-label name="H06 IDT_10nt_534 (GTAATGCGGC-CTTGAATTCG)" />
+    <reagent-label name="E06 IDT_10nt_495 (AATGGTCTAC-CCATAAGAGG)" />
+    <reagent-label name="D06 IDT_10nt_480 (AGACGTGTTA-TTACAGTTGG)" />
+    <reagent-label name="G09 IDT_10nt_523 (CTCGCATAGA-CTAGATAACG)" />
+    <reagent-label name="E09 IDT_10nt_498 (CGCTTCTCCT-TTGGCTAGGC)" />
+    <reagent-label name="B09 IDT_10nt_457 (AATGGACCTT-TATCCAACGA)" />
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407206.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407206.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407206?state=1899655" limsid="92-2407206">
+    <name>Qubit Measurement</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306114" limsid="24-306114" />
+    <qc-flag>PASSED</qc-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC7965A63" limsid="ACC7965A63" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A2" limsid="ACC9531A2" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A3" limsid="ACC9531A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A4" limsid="ACC9531A4" />
+    <reagent-label name="C06 IDT_10nt_467 (GAAGGAGCCT-CCTCCATTAT)" />
+    <reagent-label name="B06 IDT_10nt_454 (ATTCTTGCCT-GTGCAGCTAC)" />
+    <reagent-label name="D06 IDT_10nt_480 (AGACGTGTTA-TTACAGTTGG)" />
+    <reagent-label name="E09 IDT_10nt_498 (CGCTTCTCCT-TTGGCTAGGC)" />
+    <udf:field type="Numeric" name="Amount (ng)">46.65</udf:field>
+    <udf:field type="Numeric" name="Concentration">1.555</udf:field>
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407207.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407207.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407207?state=1899656" limsid="92-2407207">
+    <name>Qubit Measurement</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306114" limsid="24-306114" />
+    <qc-flag>PASSED</qc-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC8254A27" limsid="ACC8254A27" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9500A1" limsid="ACC9500A1" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9500A3" limsid="ACC9500A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A3" limsid="ACC9543A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A5" limsid="ACC9543A5" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A13" limsid="ACC9543A13" />
+    <reagent-label name="E07 IDT_10nt_496 (GTTGCCTGAC-TTGGCAACCG)" />
+    <reagent-label name="A07 IDT_10nt_442 (TTAACCTGCG-CTACTGATGT)" />
+    <reagent-label name="H06 IDT_10nt_534 (GTAATGCGGC-CTTGAATTCG)" />
+    <reagent-label name="E06 IDT_10nt_495 (AATGGTCTAC-CCATAAGAGG)" />
+    <reagent-label name="G09 IDT_10nt_523 (CTCGCATAGA-CTAGATAACG)" />
+    <reagent-label name="B09 IDT_10nt_457 (AATGGACCTT-TATCCAACGA)" />
+    <udf:field type="Numeric" name="Amount (ng)">53.31</udf:field>
+    <udf:field type="Numeric" name="Concentration">1.777</udf:field>
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407208.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407208.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407208?state=1900019" limsid="92-2407208">
+    <name>EPP Log</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306114" limsid="24-306114" />
+    <qc-flag>UNKNOWN</qc-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC7965A63" limsid="ACC7965A63" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC8254A27" limsid="ACC8254A27" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9500A1" limsid="ACC9500A1" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9500A3" limsid="ACC9500A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A2" limsid="ACC9531A2" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A3" limsid="ACC9531A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A4" limsid="ACC9531A4" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A3" limsid="ACC9543A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A5" limsid="ACC9543A5" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A13" limsid="ACC9543A13" />
+    <reagent-label name="C06 IDT_10nt_467 (GAAGGAGCCT-CCTCCATTAT)" />
+    <reagent-label name="B06 IDT_10nt_454 (ATTCTTGCCT-GTGCAGCTAC)" />
+    <reagent-label name="E07 IDT_10nt_496 (GTTGCCTGAC-TTGGCAACCG)" />
+    <reagent-label name="A07 IDT_10nt_442 (TTAACCTGCG-CTACTGATGT)" />
+    <reagent-label name="H06 IDT_10nt_534 (GTAATGCGGC-CTTGAATTCG)" />
+    <reagent-label name="E06 IDT_10nt_495 (AATGGTCTAC-CCATAAGAGG)" />
+    <reagent-label name="D06 IDT_10nt_480 (AGACGTGTTA-TTACAGTTGG)" />
+    <reagent-label name="G09 IDT_10nt_523 (CTCGCATAGA-CTAGATAACG)" />
+    <reagent-label name="E09 IDT_10nt_498 (CGCTTCTCCT-TTGGCTAGGC)" />
+    <reagent-label name="B09 IDT_10nt_457 (AATGGACCTT-TATCCAACGA)" />
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407213.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407213.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407213?state=1900024" limsid="92-2407213">
+    <name>EPP Log</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306116" limsid="24-306116" />
+    <qc-flag>UNKNOWN</qc-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC7965A63" limsid="ACC7965A63" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC8254A27" limsid="ACC8254A27" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9500A1" limsid="ACC9500A1" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9500A3" limsid="ACC9500A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A2" limsid="ACC9531A2" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A3" limsid="ACC9531A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9531A4" limsid="ACC9531A4" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A3" limsid="ACC9543A3" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A5" limsid="ACC9543A5" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9543A13" limsid="ACC9543A13" />
+    <reagent-label name="C06 IDT_10nt_467 (GAAGGAGCCT-CCTCCATTAT)" />
+    <reagent-label name="B06 IDT_10nt_454 (ATTCTTGCCT-GTGCAGCTAC)" />
+    <reagent-label name="E07 IDT_10nt_496 (GTTGCCTGAC-TTGGCAACCG)" />
+    <reagent-label name="A07 IDT_10nt_442 (TTAACCTGCG-CTACTGATGT)" />
+    <reagent-label name="H06 IDT_10nt_534 (GTAATGCGGC-CTTGAATTCG)" />
+    <reagent-label name="E06 IDT_10nt_495 (AATGGTCTAC-CCATAAGAGG)" />
+    <reagent-label name="D06 IDT_10nt_480 (AGACGTGTTA-TTACAGTTGG)" />
+    <reagent-label name="G09 IDT_10nt_523 (CTCGCATAGA-CTAGATAACG)" />
+    <reagent-label name="E09 IDT_10nt_498 (CGCTTCTCCT-TTGGCTAGGC)" />
+    <reagent-label name="B09 IDT_10nt_457 (AATGGACCTT-TATCCAACGA)" />
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407215.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407215.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" xmlns:file="http://genologics.com/ri/file" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407215?state=1900026" limsid="92-2407215">
+    <name>EPP Log</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306117" limsid="24-306117" />
+    <qc-flag>UNKNOWN</qc-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9476A23" limsid="ACC9476A23" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9587A3" limsid="ACC9587A3" />
+    <reagent-label name="B05 IDT_10nt_453 (CAGCACTACG-CGCCACAGAA)" />
+    <reagent-label name="A09 IDT_10nt_445 (TTGGCACTTA-GTGCGTCGTA)" />
+    <file:file limsid="40-84580" uri="http://127.0.0.1:8000/api/v2/files/40-84580" />
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407216.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407216.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407216?state=1900027" limsid="92-2407216">
+    <name>Tapestation PDF Report</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306117" limsid="24-306117" />
+    <qc-flag>UNKNOWN</qc-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9476A23" limsid="ACC9476A23" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9587A3" limsid="ACC9587A3" />
+    <reagent-label name="B05 IDT_10nt_453 (CAGCACTACG-CGCCACAGAA)" />
+    <reagent-label name="A09 IDT_10nt_445 (TTGGCACTTA-GTGCGTCGTA)" />
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407217.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407217.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407217?state=1900028" limsid="92-2407217">
+    <name>Tapestation CSV</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306117" limsid="24-306117" />
+    <qc-flag>UNKNOWN</qc-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9476A23" limsid="ACC9476A23" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9587A3" limsid="ACC9587A3" />
+    <reagent-label name="B05 IDT_10nt_453 (CAGCACTACG-CGCCACAGAA)" />
+    <reagent-label name="A09 IDT_10nt_445 (TTGGCACTTA-GTGCGTCGTA)" />
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407218.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407218.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407218?state=1900031" limsid="92-2407218">
+    <name>Fragment Analyzer KMP-00171T-A09 IDT_10nt_445 (TTGGCACTTA-GTGCGTCGTA)</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306117" limsid="24-306117" />
+    <qc-flag>PASSED</qc-flag>
+    <location>
+        <container uri="http://127.0.0.1:8000/api/v2/containers/27-241199" limsid="27-241199" />
+        <value>A:2</value>
+    </location>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9476A23" limsid="ACC9476A23" />
+    <reagent-label name="A09 IDT_10nt_445 (TTGGCACTTA-GTGCGTCGTA)" />
+    <udf:field type="Numeric" name="Size (bp)">337</udf:field>
+    <udf:field type="Numeric" name="DIN Value">9</udf:field>
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407219.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407219.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407219?state=1900032" limsid="92-2407219">
+    <name>Fragment Analyzer MOL694-22-B05 IDT_10nt_453 (CAGCACTACG-CGCCACAGAA)</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306117" limsid="24-306117" />
+    <qc-flag>PASSED</qc-flag>
+    <location>
+        <container uri="http://127.0.0.1:8000/api/v2/containers/27-241199" limsid="27-241199" />
+        <value>A:3</value>
+    </location>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9587A3" limsid="ACC9587A3" />
+    <reagent-label name="B05 IDT_10nt_453 (CAGCACTACG-CGCCACAGAA)" />
+    <udf:field type="Numeric" name="Size (bp)">288</udf:field>
+    <udf:field type="Numeric" name="DIN Value">9</udf:field>
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407223.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407223.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407223?state=1899661" limsid="92-2407223">
+    <name>Qubit Measurement</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306119" limsid="24-306119" />
+    <qc-flag>PASSED</qc-flag>
+    <location>
+        <container uri="http://127.0.0.1:8000/api/v2/containers/27-241200" limsid="27-241200" />
+        <value>A:2</value>
+    </location>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9476A23" limsid="ACC9476A23" />
+    <reagent-label name="A09 IDT_10nt_445 (TTGGCACTTA-GTGCGTCGTA)" />
+    <udf:field type="Numeric" name="Concentration">1.2121</udf:field>
+    <udf:field type="Numeric" name="Amount (ng)">36.363</udf:field>
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407224.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407224.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407224?state=1899662" limsid="92-2407224">
+    <name>Qubit Measurement</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306119" limsid="24-306119" />
+    <qc-flag>PASSED</qc-flag>
+    <location>
+        <container uri="http://127.0.0.1:8000/api/v2/containers/27-241200" limsid="27-241200" />
+        <value>A:3</value>
+    </location>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9587A3" limsid="ACC9587A3" />
+    <reagent-label name="B05 IDT_10nt_453 (CAGCACTACG-CGCCACAGAA)" />
+    <udf:field type="Numeric" name="Concentration">1.8</udf:field>
+    <udf:field type="Numeric" name="Amount (ng)">54</udf:field>
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407225.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407225.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407225?state=1900038" limsid="92-2407225">
+    <name>EPP Log</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306119" limsid="24-306119" />
+    <qc-flag>UNKNOWN</qc-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9476A23" limsid="ACC9476A23" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9587A3" limsid="ACC9587A3" />
+    <reagent-label name="B05 IDT_10nt_453 (CAGCACTACG-CGCCACAGAA)" />
+    <reagent-label name="A09 IDT_10nt_445 (TTGGCACTTA-GTGCGTCGTA)" />
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407226.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407226.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407226?state=1900039" limsid="92-2407226">
+    <name>Quantit Result File</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306119" limsid="24-306119" />
+    <qc-flag>UNKNOWN</qc-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9476A23" limsid="ACC9476A23" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9587A3" limsid="ACC9587A3" />
+    <reagent-label name="B05 IDT_10nt_453 (CAGCACTACG-CGCCACAGAA)" />
+    <reagent-label name="A09 IDT_10nt_445 (TTGGCACTTA-GTGCGTCGTA)" />
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/artifacts/92-2407227.xml
+++ b/tests/fixtures/aggregate_qc/artifacts/92-2407227.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" xmlns:file="http://genologics.com/ri/file" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407227?state=1900040" limsid="92-2407227">
+    <name>EPP Log</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-306120" limsid="24-306120" />
+    <qc-flag>UNKNOWN</qc-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9476A23" limsid="ACC9476A23" />
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC9587A3" limsid="ACC9587A3" />
+    <reagent-label name="B05 IDT_10nt_453 (CAGCACTACG-CGCCACAGAA)" />
+    <reagent-label name="A09 IDT_10nt_445 (TTGGCACTTA-GTGCGTCGTA)" />
+    <file:file limsid="40-84582" uri="http://127.0.0.1:8000/api/v2/files/40-84582" />
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/aggregate_qc/processes/24-306112.xml
+++ b/tests/fixtures/aggregate_qc/processes/24-306112.xml
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='utf-8'?>
+<prc:process xmlns:prc="http://genologics.com/ri/process" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/processes/24-306112" limsid="24-306112">
+    <type uri="http://127.0.0.1:8000/api/v2/processtypes/1371">Tapestation QC TWIST v2</type>
+    <date-run>2022-03-17</date-run>
+    <technician uri="http://127.0.0.1:8000/api/v2/researchers/1154">
+        <first-name>Karl</first-name>
+        <last-name>Svärd</last-name>
+    </technician>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049?state=1887755" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049?state=1887755" limsid="2-2392049">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407146?state=1900003" output-generation-type="PerInput" output-type="ResultFile" limsid="92-2407146" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049?state=1887755" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049?state=1887755" limsid="2-2392049">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407148?state=1900005" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407148" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049?state=1887755" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049?state=1887755" limsid="2-2392049">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407149?state=1900006" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407149" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049?state=1887755" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049?state=1887755" limsid="2-2392049">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407150?state=1900007" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407150" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301?state=1887754" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301?state=1887754" limsid="2-2392301">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407147?state=1900004" output-generation-type="PerInput" output-type="ResultFile" limsid="92-2407147" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301?state=1887754" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301?state=1887754" limsid="2-2392301">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407148?state=1900005" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407148" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301?state=1887754" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301?state=1887754" limsid="2-2392301">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407149?state=1900006" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407149" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301?state=1887754" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301?state=1887754" limsid="2-2392301">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407150?state=1900007" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407150" />
+    </input-output-map>
+    <udf:field type="String" name="Assay">D1000</udf:field>
+    <udf:field type="String" name="Criteria 1 - Operator">&gt;=</udf:field>
+    <udf:field type="String" name="Criteria 1 - Source Data Field">Size (bp)</udf:field>
+    <udf:field type="Numeric" name="Criteria 1 - Threshold Value">300</udf:field>
+    <udf:field type="String" name="Document version">12</udf:field>
+    <udf:field type="String" name="Lot no kit:">12</udf:field>
+    <udf:field type="String" name="Method document">1212</udf:field>
+</prc:process>

--- a/tests/fixtures/aggregate_qc/processes/24-306114.xml
+++ b/tests/fixtures/aggregate_qc/processes/24-306114.xml
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='utf-8'?>
+<prc:process xmlns:prc="http://genologics.com/ri/process" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/processes/24-306114" limsid="24-306114">
+    <type uri="http://127.0.0.1:8000/api/v2/processtypes/1369">Qubit QC (Library Validation) v2</type>
+    <date-run>2022-03-17</date-run>
+    <technician uri="http://127.0.0.1:8000/api/v2/researchers/1154">
+        <first-name>Karl</first-name>
+        <last-name>Svärd</last-name>
+    </technician>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049?state=1887755" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049?state=1887755" limsid="2-2392049">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407206?state=1900017" output-generation-type="PerInput" output-type="ResultFile" limsid="92-2407206" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049?state=1887755" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049?state=1887755" limsid="2-2392049">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407208?state=1900019" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407208" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301?state=1887754" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301?state=1887754" limsid="2-2392301">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407207?state=1900018" output-generation-type="PerInput" output-type="ResultFile" limsid="92-2407207" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301?state=1887754" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301?state=1887754" limsid="2-2392301">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407208?state=1900019" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407208" />
+    </input-output-map>
+    <udf:field type="Numeric" name="Amount Needed (ng)">30</udf:field>
+    <udf:field type="String" name="Assay">dsDNA BR</udf:field>
+    <udf:field type="String" name="Document Version">14</udf:field>
+    <udf:field type="String" name="Instrument">Duplo</udf:field>
+    <udf:field type="String" name="Lot no: Qubit kit">12</udf:field>
+    <udf:field type="String" name="Method document">1026</udf:field>
+    <udf:field type="String" name="Minimum requiered Amount (ng)">750</udf:field>
+    <udf:field type="String" name="Minimum requiered Amount (nM)">750</udf:field>
+    <udf:field type="Numeric" name="Minimum required amount (ng)">750</udf:field>
+    <udf:field type="String" name="Minimum required Concentration">0.3</udf:field>
+    <udf:field type="Numeric" name="Sample Volume (ul)">30</udf:field>
+    <process-parameter name="Calculate amount and set QC" />
+</prc:process>

--- a/tests/fixtures/aggregate_qc/processes/24-306116.xml
+++ b/tests/fixtures/aggregate_qc/processes/24-306116.xml
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='utf-8'?>
+<prc:process xmlns:prc="http://genologics.com/ri/process" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/processes/24-306116" limsid="24-306116">
+    <type uri="http://127.0.0.1:8000/api/v2/processtypes/1356">Aggregate QC (Library Validation) TWIST v2</type>
+    <technician uri="http://127.0.0.1:8000/api/v2/researchers/1154">
+        <first-name>Karl</first-name>
+        <last-name>Svärd</last-name>
+    </technician>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049?state=1887755" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049?state=1887755" limsid="2-2392049">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407213?state=1900024" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407213" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049?state=1887755" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392049?state=1887755" limsid="2-2392049">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407214?state=1900025" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407214" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301?state=1887754" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301?state=1887754" limsid="2-2392301">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407213?state=1900024" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407213" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301?state=1887754" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2392301?state=1887754" limsid="2-2392301">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-304228" limsid="24-304228" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407214?state=1900025" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407214" />
+    </input-output-map>
+    <udf:field type="String" name="Automated Quant-iT QC (Library Validation) 4.0">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="Bioanalyzer QC (Library Validation) 4.0">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="CaliperGX QC (DNA)">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="CG001 - Fragment analyzer QC">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="CG001- Tapestation QC (Dev)">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="CG002 - Fragment analyzer QC">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="CG002 - qPCR QC (Library Validation) (Dev)">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="CG002 - Quantit QC (Library Validation)">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="CG002 - Qubit QC (Library Validation)">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="CG002 - Qubit QC (Library Validation) (Dev)">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="Copy task 1 - Source Field">Size (bp)</udf:field>
+    <udf:field type="String" name="Copy task 2 - Source Field">Concentration</udf:field>
+    <udf:field type="String" name="Copy task 3 - Source Field">Amount (ng)</udf:field>
+    <udf:field type="String" name="Criteria 1 - Operator">&gt;=</udf:field>
+    <udf:field type="Numeric" name="Criteria 1 - Threshold Value">2</udf:field>
+    <udf:field type="String" name="Customer Gel QC">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="PicoGreen QC (Library Validation) 4.0">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="Quant-iT QC (Library Validation) 4.0">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="Copy task 1 - Source Step">Tapestation QC TWIST v2</udf:field>
+    <udf:field type="String" name="Copy task 2 - Source Step">Qubit QC (Library Validation) v2</udf:field>
+    <udf:field type="String" name="Copy task 3 - Source Step">Qubit QC (Library Validation) v2</udf:field>
+    <protocol-name>Twist Qubit</protocol-name>
+    <process-parameter name="1. Aggregate QC Flags and Copy Fields" />
+</prc:process>

--- a/tests/fixtures/aggregate_qc/processes/24-306117.xml
+++ b/tests/fixtures/aggregate_qc/processes/24-306117.xml
@@ -1,0 +1,65 @@
+<?xml version='1.0' encoding='utf-8'?>
+<prc:process xmlns:prc="http://genologics.com/ri/process" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/processes/24-306117" limsid="24-306117">
+    <type uri="http://127.0.0.1:8000/api/v2/processtypes/1371">Tapestation QC TWIST v2</type>
+    <date-run>2022-03-17</date-run>
+    <technician uri="http://127.0.0.1:8000/api/v2/researchers/1154">
+        <first-name>Karl</first-name>
+        <last-name>Svärd</last-name>
+    </technician>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" limsid="2-2406340">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407215?state=1900026" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407215" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" limsid="2-2406340">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407216?state=1900027" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407216" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" limsid="2-2406340">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407217?state=1900028" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407217" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" limsid="2-2406340">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407218?state=1900029" output-generation-type="PerInput" output-type="ResultFile" limsid="92-2407218" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" limsid="2-2406348">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407215?state=1900026" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407215" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" limsid="2-2406348">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407216?state=1900027" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407216" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" limsid="2-2406348">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407217?state=1900028" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407217" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" limsid="2-2406348">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407219?state=1900030" output-generation-type="PerInput" output-type="ResultFile" limsid="92-2407219" />
+    </input-output-map>
+    <udf:field type="String" name="Assay">D1000 HS</udf:field>
+    <udf:field type="String" name="Criteria 1 - Operator">&gt;=</udf:field>
+    <udf:field type="String" name="Criteria 1 - Source Data Field">Size (bp)</udf:field>
+    <udf:field type="Numeric" name="Criteria 1 - Threshold Value">300</udf:field>
+    <udf:field type="String" name="Document version">12</udf:field>
+    <udf:field type="String" name="Lot no kit:">12</udf:field>
+    <udf:field type="String" name="Method document">1212</udf:field>
+    <process-parameter name="Copy DIN from Aggregate QC (DNA)" />
+</prc:process>

--- a/tests/fixtures/aggregate_qc/processes/24-306119.xml
+++ b/tests/fixtures/aggregate_qc/processes/24-306119.xml
@@ -1,0 +1,57 @@
+<?xml version='1.0' encoding='utf-8'?>
+<prc:process xmlns:prc="http://genologics.com/ri/process" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/processes/24-306119" limsid="24-306119">
+    <type uri="http://127.0.0.1:8000/api/v2/processtypes/1367">Quantit QC (Library Validation) TWIST v2</type>
+    <date-run>2022-03-17</date-run>
+    <technician uri="http://127.0.0.1:8000/api/v2/researchers/1154">
+        <first-name>Karl</first-name>
+        <last-name>Svärd</last-name>
+    </technician>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" limsid="2-2406340">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407223?state=1900036" output-generation-type="PerInput" output-type="ResultFile" limsid="92-2407223" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" limsid="2-2406340">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407225?state=1900038" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407225" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" limsid="2-2406340">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407226?state=1900039" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407226" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" limsid="2-2406348">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407224?state=1900037" output-generation-type="PerInput" output-type="ResultFile" limsid="92-2407224" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" limsid="2-2406348">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407225?state=1900038" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407225" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" limsid="2-2406348">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407226?state=1900039" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407226" />
+    </input-output-map>
+    <udf:field type="Numeric" name="Amount Needed (ng)">30</udf:field>
+    <udf:field type="String" name="Assay">dsDNA HS</udf:field>
+    <udf:field type="String" name="Criteria 1 - Operator">&gt;=</udf:field>
+    <udf:field type="String" name="Criteria 1 - Source Data Field">Concentration</udf:field>
+    <udf:field type="Numeric" name="Criteria 1 - Threshold Value">2</udf:field>
+    <udf:field type="String" name="Document Version">8</udf:field>
+    <udf:field type="String" name="Lot no: Quantification kit">12</udf:field>
+    <udf:field type="String" name="Method document">1843</udf:field>
+    <udf:field type="String" name="Method Document 2">1843</udf:field>
+    <udf:field type="Numeric" name="Sample Volume (ul)">30</udf:field>
+    <udf:field type="String" name="Instrument">Kratos</udf:field>
+    <process-parameter name="Calculate amount and set QC" />
+</prc:process>

--- a/tests/fixtures/aggregate_qc/processes/24-306120.xml
+++ b/tests/fixtures/aggregate_qc/processes/24-306120.xml
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='utf-8'?>
+<prc:process xmlns:prc="http://genologics.com/ri/process" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/processes/24-306120" limsid="24-306120">
+    <type uri="http://127.0.0.1:8000/api/v2/processtypes/1356">Aggregate QC (Library Validation) TWIST v2</type>
+    <technician uri="http://127.0.0.1:8000/api/v2/researchers/1154">
+        <first-name>Karl</first-name>
+        <last-name>Svärd</last-name>
+    </technician>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" limsid="2-2406340">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407227?state=1900040" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407227" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406340?state=1899587" limsid="2-2406340">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407228?state=1900041" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407228" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" limsid="2-2406348">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407227?state=1900040" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407227" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" uri="http://127.0.0.1:8000/api/v2/artifacts/2-2406348?state=1899588" limsid="2-2406348">
+            <parent-process uri="http://127.0.0.1:8000/api/v2/processes/151-305928" limsid="151-305928" />
+        </input>
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2407228?state=1900041" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2407228" />
+    </input-output-map>
+    <udf:field type="Numeric" name="Criteria 1 - Threshold Value">2</udf:field>
+    <udf:field type="String" name="Automated Quant-iT QC (Library Validation) 4.0">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="Bioanalyzer QC (Library Validation) 4.0">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="CaliperGX QC (DNA)">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="CG001 - Fragment analyzer QC">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="CG001- Tapestation QC (Dev)">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="CG002 - Fragment analyzer QC">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="CG002 - qPCR QC (Library Validation) (Dev)">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="CG002 - Quantit QC (Library Validation)">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="CG002 - Qubit QC (Library Validation)">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="CG002 - Qubit QC (Library Validation) (Dev)">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="Copy task 1 - Source Field">Size (bp)</udf:field>
+    <udf:field type="String" name="Copy task 1 - Source Step">Tapestation QC TWIST v2</udf:field>
+    <udf:field type="String" name="Copy task 2 - Source Field">Concentration</udf:field>
+    <udf:field type="String" name="Copy task 2 - Source Step">Quantit QC (Library Validation) TWIST v2</udf:field>
+    <udf:field type="String" name="Copy task 3 - Source Field">Amount (ng)</udf:field>
+    <udf:field type="String" name="Copy task 3 - Source Step">Quantit QC (Library Validation) TWIST v2</udf:field>
+    <udf:field type="String" name="Criteria 1 - Operator">&gt;=</udf:field>
+    <udf:field type="String" name="Customer Gel QC">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="PicoGreen QC (Library Validation) 4.0">Use if available (Priority 5)</udf:field>
+    <udf:field type="String" name="Quant-iT QC (Library Validation) 4.0">Use if available (Priority 5)</udf:field>
+    <protocol-name>Twist Qubit</protocol-name>
+    <process-parameter name="Calculate Molar Concentration and Set QC" />
+</prc:process>


### PR DESCRIPTION
### Added
Moves the **Aggregate QC and Copy Fields** EPP to `cg_lims`. Includes testing, new udf related functions and adds some functionality to the `get_latest_artifact` function.


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


