### PR TITLE
Add support for tagmentation in RB buffer calc

### DIFF
--- a/cg_lims/EPPs/udf/calculate/calculate_resuspension_buffer_volumes.py
+++ b/cg_lims/EPPs/udf/calculate/calculate_resuspension_buffer_volumes.py
@@ -19,8 +19,10 @@ LOG = logging.getLogger(__name__)
 
 AMOUNT_NEEDED_LUCIGEN = 200
 AMOUNT_NEEDED_TRUSEQ = 1100
+AMOUNT_NEEDED_TAGMENTATION = 500
 TOTAL_VOLUME_LUCIGEN = 25
 TOTAL_VOLUME_TRUSEQ = 55
+TOTAL_VOLUME_TAGMENTATION = 25
 
 
 def calculate_rb_volume(artifacts: List[Artifact]):
@@ -29,22 +31,25 @@ def calculate_rb_volume(artifacts: List[Artifact]):
     for artifact in artifacts:
         concentration = artifact.udf.get("Concentration")
         amount_needed = artifact.udf.get("Amount needed (ng)")
+        allowed_amounts = [AMOUNT_NEEDED_LUCIGEN, AMOUNT_NEEDED_TRUSEQ, AMOUNT_NEEDED_TAGMENTATION]
         if concentration is None:
             LOG.error(
                 f"Sample {artifact.id} is missing udf 'Concentration'."
             )
             missing_udfs += 1
             continue
-        if amount_needed not in [AMOUNT_NEEDED_LUCIGEN, AMOUNT_NEEDED_TRUSEQ]:
+        if amount_needed not in allowed_amounts:
             raise InvalidValueError(
                 f"'Amount needed (ng)' missing or incorrect for one or more samples. Value can "
-                f"only be {', '.join(map(str, [AMOUNT_NEEDED_LUCIGEN, AMOUNT_NEEDED_TRUSEQ]))}."
+                f"only be {', '.join(map(str, allowed_amounts))}."
             )
         sample_volume = amount_needed / concentration
         if amount_needed == AMOUNT_NEEDED_LUCIGEN:
             artifact.udf["RB Volume (ul)"] = TOTAL_VOLUME_LUCIGEN - sample_volume
         if amount_needed == AMOUNT_NEEDED_TRUSEQ:
             artifact.udf["RB Volume (ul)"] = TOTAL_VOLUME_TRUSEQ - sample_volume
+        if amount_needed == AMOUNT_NEEDED_TAGMENTATION:
+            artifact.udf["RB Volume (ul)"] = TOTAL_VOLUME_TAGMENTATION - sample_volume
         artifact.udf["Sample Volume (ul)"] = sample_volume
         artifact.put()
 

--- a/tests/EPPs/udf/calculate/test_calculate_resuspension_buffer_volumes.py
+++ b/tests/EPPs/udf/calculate/test_calculate_resuspension_buffer_volumes.py
@@ -74,6 +74,7 @@ def test_calculate_rb_volume_invalid_amount_needed(
     "concentration, amount_needed, expected_rb_volume, expected_sample_volume",
     [
         (100, 200, 23.0, 2.0),
+        (100, 500, 20.0, 5.0),
         (100, 1100, 44.0, 11.0),
     ],
 )


### PR DESCRIPTION
### Added
Adds support for tagmentation prep in the calculate_resuspension_buffer_volumes.py script.


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


