### PR TITLE
New EPPs and fixes needed for Quantit on hamilton

### DIFF
--- a/cg_lims/EPPs/files/hamilton/normalization_file.py
+++ b/cg_lims/EPPs/files/hamilton/normalization_file.py
@@ -88,15 +88,21 @@ def get_file_data_and_write(
 @options.buffer_udf()
 @options.volume_udf()
 @options.pooling_step()
+@options.measurement()
 @click.pass_context
 def barcode_file(
-    ctx: click.Context, file: str, volume_udf: str, buffer_udf: str, pooling_step: bool
+        ctx: click.Context,
+        file: str,
+        volume_udf: str,
+        buffer_udf: str,
+        pooling_step: bool,
+        measurement: bool = False,
 ):
     """Script to make a hamilton normalization file"""
 
     LOG.info(f"Running {ctx.command_path} with params: {ctx.params}")
     process = ctx.obj["process"]
-    artifacts = get_artifacts(process=process, input=False)
+    artifacts = get_artifacts(process=process, measurement=measurement)
     try:
         get_file_data_and_write(
             pool=pooling_step,

--- a/cg_lims/EPPs/files/hamilton/normalization_file.py
+++ b/cg_lims/EPPs/files/hamilton/normalization_file.py
@@ -107,7 +107,7 @@ def barcode_file(
         get_file_data_and_write(
             pool=pooling_step,
             destination_artifacts=artifacts,
-            file=f"{file}-hamilton-normalization.txt",
+            file=f"{file}-hamilton-normalization.csv",
             volume_udf=volume_udf,
             buffer_udf=buffer_udf,
         )

--- a/cg_lims/EPPs/udf/copy/base.py
+++ b/cg_lims/EPPs/udf/copy/base.py
@@ -12,6 +12,8 @@ from cg_lims.EPPs.udf.copy.process_to_artifact import process_to_artifact
 from cg_lims.EPPs.udf.copy.qc_to_sample import qc_to_sample
 from cg_lims.EPPs.udf.copy.original_well_to_sample import original_position_to_sample
 from cg_lims.EPPs.udf.copy.aggregate_qc_flags_and_copy_fields import aggregate_qc_and_copy_fields
+from cg_lims.EPPs.udf.copy.measurement_to_analyte import measurement_to_analyte
+
 
 @click.group(invoke_without_command=True)
 @click.pass_context
@@ -29,3 +31,4 @@ copy.add_command(process_to_artifact)
 copy.add_command(qc_to_sample)
 copy.add_command(original_position_to_sample)
 copy.add_command(aggregate_qc_and_copy_fields)
+copy.add_command(measurement_to_analyte)

--- a/cg_lims/EPPs/udf/copy/measurement_to_analyte.py
+++ b/cg_lims/EPPs/udf/copy/measurement_to_analyte.py
@@ -1,0 +1,68 @@
+from typing import List, Tuple
+from genologics.entities import Artifact
+
+from cg_lims import options
+from cg_lims.exceptions import LimsError, MissingUDFsError
+from cg_lims.get.artifacts import get_artifacts
+from cg_lims.set.udfs import copy_artifact_to_artifact
+
+import logging
+import sys
+import click
+
+LOG = logging.getLogger(__name__)
+
+
+def copy_udfs_to_all_analytes(
+    measurements: List[Artifact],
+    udfs: List[Tuple[str, str]],
+):
+    """Looping over all analytes and copying over the measurement values for the given UDFs."""
+
+    failed_artifacts = 0
+    print(f"Measurements: {measurements}")
+    for measurement in measurements:
+        try:
+            analyte = measurement.input_artifact_list()[0]
+            print(f"Analyte: {analyte}")
+            copy_artifact_to_artifact(
+                destination_artifact=analyte,
+                source_artifact=measurement,
+                artifact_udfs=udfs,
+            )
+        except:
+            failed_artifacts += 1
+    if failed_artifacts:
+        raise MissingUDFsError(
+            message=f"Failed to set artifact udfs on {failed_artifacts} artifacts. See log for details"
+        )
+
+
+@click.command()
+@options.artifact_udfs(
+    help="The name of the udf that you want to set"
+)
+@click.pass_context
+def measurement_to_analyte(
+    ctx,
+    artifact_udfs: List[str],
+):
+    """
+    Script to copy UDFs to measurements in the current step, from their source analytes in the same step.
+    """
+
+    LOG.info(f"Running {ctx.command_path} with params: {ctx.params}")
+    process = ctx.obj["process"]
+
+    udfs = list(zip(artifact_udfs, artifact_udfs))
+    print(f"UDF object: {udfs}")
+
+    try:
+        measurements = get_artifacts(process=process, measurement=True)
+        copy_udfs_to_all_analytes(
+            measurements=measurements,
+            udfs=udfs,
+        )
+        click.echo("Udfs have been set on all samples.")
+    except LimsError as e:
+        sys.exit(e.message)

--- a/cg_lims/EPPs/udf/copy/measurement_to_analyte.py
+++ b/cg_lims/EPPs/udf/copy/measurement_to_analyte.py
@@ -20,11 +20,9 @@ def copy_udfs_to_all_analytes(
     """Looping over all analytes and copying over the measurement values for the given UDFs."""
 
     failed_artifacts = 0
-    print(f"Measurements: {measurements}")
     for measurement in measurements:
         try:
             analyte = measurement.input_artifact_list()[0]
-            print(f"Analyte: {analyte}")
             copy_artifact_to_artifact(
                 destination_artifact=analyte,
                 source_artifact=measurement,
@@ -55,7 +53,6 @@ def measurement_to_analyte(
     process = ctx.obj["process"]
 
     udfs = list(zip(artifact_udfs, artifact_udfs))
-    print(f"UDF object: {udfs}")
 
     try:
         measurements = get_artifacts(process=process, measurement=True)

--- a/tests/EPPs/udf/copy/test_measurement_to_analyte.py
+++ b/tests/EPPs/udf/copy/test_measurement_to_analyte.py
@@ -1,0 +1,51 @@
+import pytest
+from genologics.entities import Artifact, Process
+
+from cg_lims.EPPs.udf.copy.measurement_to_analyte import copy_udfs_to_all_analytes
+from cg_lims.get.artifacts import get_artifacts, get_latest_analyte
+from cg_lims.exceptions import MissingUDFsError
+from tests.conftest import server
+
+
+def test_copy_udf(lims):
+    # GIVEN a Reception control WGS process with sample measurements which are connected to analytes, measurements
+    # have barcodes stored in UDF "Output Container Barcode"
+    server("reception_control_wgs")
+    process = Process(lims, id="24-349794")
+    measurements = get_artifacts(process=process, measurement=True)
+    analytes = get_artifacts(process=process, input=True)
+    barcodes = {
+        "ACC10237A2": "barcode1",
+        "ACC10242A8": "barcode2",
+        "ACC10243A1": "barcode3",
+    }
+    udfs = [("Output Container Barcode", "Output Container Barcode")]
+    for measurement in measurements:
+        measurement.udf["Output Container Barcode"] = barcodes[measurement.samples[0].id]
+
+    # WHEN running copy_udfs_to_all_analytes to copy the barcodes
+    copy_udfs_to_all_analytes(
+        measurements=measurements,
+        udfs=udfs,
+    )
+
+    # THEN the correct source UDFs are copied over to the correct analytes
+    for analyte in analytes:
+        assert analyte.udf["Output Container Barcode"] == barcodes[analyte.samples[0].id]
+
+
+def test_copy_udf_missing_udfs(lims):
+    # GIVEN a Reception control WGS process with sample measurements which are connected to analytes, measurements
+    # don't have values stored in the required UDF
+    server("reception_control_wgs")
+    process = Process(lims, id="24-349794")
+    measurements = get_artifacts(process=process, measurement=True)
+    udfs = [("Output Container Barcode", "Output Container Barcode")]
+
+    # WHEN when running copy_udfs_to_all_analytes
+    # THEN MissingUDFsError is raised
+    with pytest.raises(MissingUDFsError) as error_message:
+        copy_udfs_to_all_analytes(
+            measurements=measurements,
+            udfs=udfs,
+        )

--- a/tests/fixtures/reception_control_wgs/artifacts/92-2762637.xml
+++ b/tests/fixtures/reception_control_wgs/artifacts/92-2762637.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2762637?state=2190591" limsid="92-2762637">
+    <name>2022-19139-03</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-349794" limsid="24-349794" />
+    <qc-flag>UNKNOWN</qc-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC10237A2" limsid="ACC10237A2" />
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/reception_control_wgs/artifacts/92-2762638.xml
+++ b/tests/fixtures/reception_control_wgs/artifacts/92-2762638.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2762638?state=2190592" limsid="92-2762638">
+    <name>22242-I-1A</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-349794" limsid="24-349794" />
+    <qc-flag>UNKNOWN</qc-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC10242A8" limsid="ACC10242A8" />
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/reception_control_wgs/artifacts/92-2762639.xml
+++ b/tests/fixtures/reception_control_wgs/artifacts/92-2762639.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" uri="http://127.0.0.1:8000/api/v2/artifacts/92-2762639?state=2190593" limsid="92-2762639">
+    <name>DNA-T-K10632-22</name>
+    <type>ResultFile</type>
+    <output-type>ResultFile</output-type>
+    <parent-process uri="http://127.0.0.1:8000/api/v2/processes/24-349794" limsid="24-349794" />
+    <qc-flag>UNKNOWN</qc-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC10243A1" limsid="ACC10243A1" />
+    <workflow-stages />
+</art:artifact>

--- a/tests/fixtures/reception_control_wgs/artifacts/ACC10237A2PA1.xml
+++ b/tests/fixtures/reception_control_wgs/artifacts/ACC10237A2PA1.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10237A2PA1?state=2188186" limsid="ACC10237A2PA1">
+    <name>2022-19139-03</name>
+    <type>Analyte</type>
+    <output-type>Analyte</output-type>
+    <qc-flag>UNKNOWN</qc-flag>
+    <location>
+        <container uri="http://127.0.0.1:8000/api/v2/containers/27-271527" limsid="27-271527" />
+        <value>1:1</value>
+    </location>
+    <working-flag>true</working-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC10237A2" limsid="ACC10237A2" />
+    <udf:field type="Numeric" name="Amount (ng)">3464.558</udf:field>
+    <udf:field type="Numeric" name="Volume (ul)">50</udf:field>
+    <udf:field type="Numeric" name="Concentration">73.714</udf:field>
+    <udf:field type="String" name="Output Container Barcode">10237A2</udf:field>
+    <artifact-group name="CG001 Genotyping" uri="http://127.0.0.1:8000/api/v2/artifactgroups/701" />
+    <artifact-group name="WGS PCR free v5" uri="http://127.0.0.1:8000/api/v2/artifactgroups/1511" />
+    <workflow-stages>
+        <workflow-stage status="REMOVED" name="CG002 - Plate Setup MAF" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/701/stages/1401" />
+        <workflow-stage status="COMPLETE" name="Aliquot Samples for Covaris" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1760/stages/6064" />
+        <workflow-stage status="COMPLETE" name="Initial QC wgs v4" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1760/stages/6063" />
+        <workflow-stage status="QUEUED" name="Aliquot Samples for Covaris" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1760/stages/6064" />
+        <workflow-stage status="COMPLETE" name="Initial QC wgs v4" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1760/stages/6063" />
+        <workflow-stage status="IN_PROGRESS" name="Initial QC wgs v4" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1760/stages/6063" />
+    </workflow-stages>
+</art:artifact>

--- a/tests/fixtures/reception_control_wgs/artifacts/ACC10242A8PA1.xml
+++ b/tests/fixtures/reception_control_wgs/artifacts/ACC10242A8PA1.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A8PA1?state=2188499" limsid="ACC10242A8PA1">
+    <name>22242-I-1A</name>
+    <type>Analyte</type>
+    <output-type>Analyte</output-type>
+    <qc-flag>UNKNOWN</qc-flag>
+    <location>
+        <container uri="http://127.0.0.1:8000/api/v2/containers/27-271566" limsid="27-271566" />
+        <value>H:1</value>
+    </location>
+    <working-flag>true</working-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC10242A8" limsid="ACC10242A8" />
+    <udf:field type="Numeric" name="Amount (ng)">8018.395</udf:field>
+    <udf:field type="Boolean" name="Skip Buffer Exchange">false</udf:field>
+    <udf:field type="Numeric" name="Volume (ul)">80</udf:field>
+    <udf:field type="Numeric" name="Concentration">104.135</udf:field>
+    <udf:field type="Numeric" name="Level of Multiplexing">8</udf:field>
+    <udf:field type="String" name="Output Container Barcode">2213347 C SciL OP_20220721_1419_5QNN</udf:field>
+    <artifact-group name="CG001 Genotyping" uri="http://127.0.0.1:8000/api/v2/artifactgroups/701" />
+    <artifact-group name="WGS PCR free v5" uri="http://127.0.0.1:8000/api/v2/artifactgroups/1511" />
+    <artifact-group name="WGS PCR-Free Tagmentation v.2" uri="http://127.0.0.1:8000/api/v2/artifactgroups/1804" />
+    <workflow-stages>
+        <workflow-stage status="QUEUED" name="CG002 - Plate Setup MAF" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/701/stages/1401" />
+        <workflow-stage status="COMPLETE" name="Aliquot Samples for Covaris" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1760/stages/6064" />
+        <workflow-stage status="COMPLETE" name="Sample Placement (WGS) v.1" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/2005/stages/7501" />
+        <workflow-stage status="IN_PROGRESS" name="Initial QC wgs v4" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1760/stages/6063" />
+    </workflow-stages>
+</art:artifact>

--- a/tests/fixtures/reception_control_wgs/artifacts/ACC10243A1PA1.xml
+++ b/tests/fixtures/reception_control_wgs/artifacts/ACC10243A1PA1.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='utf-8'?>
+<art:artifact xmlns:art="http://genologics.com/ri/artifact" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10243A1PA1?state=2188502" limsid="ACC10243A1PA1">
+    <name>DNA-T-K10632-22</name>
+    <type>Analyte</type>
+    <output-type>Analyte</output-type>
+    <qc-flag>UNKNOWN</qc-flag>
+    <location>
+        <container uri="http://127.0.0.1:8000/api/v2/containers/27-271567" limsid="27-271567" />
+        <value>A:1</value>
+    </location>
+    <working-flag>true</working-flag>
+    <sample uri="http://127.0.0.1:8000/api/v2/samples/ACC10243A1" limsid="ACC10243A1" />
+    <udf:field type="Numeric" name="Amount (ng)">9625.217</udf:field>
+    <udf:field type="Numeric" name="Volume (ul)">40</udf:field>
+    <udf:field type="Numeric" name="Concentration">260.141</udf:field>
+    <udf:field type="String" name="Output Container Barcode">plate1</udf:field>
+    <artifact-group name="WGS PCR free v5" uri="http://127.0.0.1:8000/api/v2/artifactgroups/1511" />
+    <workflow-stages>
+        <workflow-stage status="COMPLETE" name="Aliquot Samples for Covaris" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1760/stages/6064" />
+        <workflow-stage status="COMPLETE" name="Initial QC wgs v4" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1760/stages/6063" />
+        <workflow-stage status="IN_PROGRESS" name="Initial QC wgs v4" uri="http://127.0.0.1:8000/api/v2/configuration/workflows/1760/stages/6063" />
+    </workflow-stages>
+</art:artifact>

--- a/tests/fixtures/reception_control_wgs/containers/27-271527.xml
+++ b/tests/fixtures/reception_control_wgs/containers/27-271527.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8'?>
+<con:container xmlns:con="http://genologics.com/ri/container" uri="http://127.0.0.1:8000/api/v2/containers/27-271527" limsid="27-271527">
+    <name>2022-19139-03</name>
+    <type uri="http://127.0.0.1:8000/api/v2/containertypes/2" name="Tube" />
+    <occupied-wells>1</occupied-wells>
+    <placement uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10237A2PA1" limsid="ACC10237A2PA1">
+        <value>1:1</value>
+    </placement>
+    <state>Populated</state>
+</con:container>

--- a/tests/fixtures/reception_control_wgs/containers/27-271566.xml
+++ b/tests/fixtures/reception_control_wgs/containers/27-271566.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='utf-8'?>
+<con:container xmlns:con="http://genologics.com/ri/container" uri="http://127.0.0.1:8000/api/v2/containers/27-271566" limsid="27-271566">
+    <name>2213347 C SciL OP_20220721_1419_5QNN</name>
+    <type uri="http://127.0.0.1:8000/api/v2/containertypes/1" name="96 well plate" />
+    <occupied-wells>10</occupied-wells>
+    <placement uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A1PA1" limsid="ACC10242A1PA1">
+        <value>A:1</value>
+    </placement>
+    <placement uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A2PA1" limsid="ACC10242A2PA1">
+        <value>B:1</value>
+    </placement>
+    <placement uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A3PA1" limsid="ACC10242A3PA1">
+        <value>C:1</value>
+    </placement>
+    <placement uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A4PA1" limsid="ACC10242A4PA1">
+        <value>D:1</value>
+    </placement>
+    <placement uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A5PA1" limsid="ACC10242A5PA1">
+        <value>E:1</value>
+    </placement>
+    <placement uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A6PA1" limsid="ACC10242A6PA1">
+        <value>F:1</value>
+    </placement>
+    <placement uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A7PA1" limsid="ACC10242A7PA1">
+        <value>G:1</value>
+    </placement>
+    <placement uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A8PA1" limsid="ACC10242A8PA1">
+        <value>H:1</value>
+    </placement>
+    <placement uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A9PA1" limsid="ACC10242A9PA1">
+        <value>A:2</value>
+    </placement>
+    <placement uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A10PA1" limsid="ACC10242A10PA1">
+        <value>B:2</value>
+    </placement>
+    <state>Populated</state>
+</con:container>

--- a/tests/fixtures/reception_control_wgs/containers/27-271567.xml
+++ b/tests/fixtures/reception_control_wgs/containers/27-271567.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='utf-8'?>
+<con:container xmlns:con="http://genologics.com/ri/container" uri="http://127.0.0.1:8000/api/v2/containers/27-271567" limsid="27-271567">
+    <name>YL037</name>
+    <type uri="http://127.0.0.1:8000/api/v2/containertypes/1" name="96 well plate" />
+    <occupied-wells>4</occupied-wells>
+    <placement uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10243A1PA1" limsid="ACC10243A1PA1">
+        <value>A:1</value>
+    </placement>
+    <placement uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10243A2PA1" limsid="ACC10243A2PA1">
+        <value>B:1</value>
+    </placement>
+    <placement uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10243A3PA1" limsid="ACC10243A3PA1">
+        <value>C:1</value>
+    </placement>
+    <placement uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10243A4PA1" limsid="ACC10243A4PA1">
+        <value>D:1</value>
+    </placement>
+    <state>Populated</state>
+</con:container>

--- a/tests/fixtures/reception_control_wgs/containertypes/1.xml
+++ b/tests/fixtures/reception_control_wgs/containertypes/1.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ctp:container-type xmlns:ctp="http://genologics.com/ri/containertype" uri="http://127.0.0.1:8000/api/v2/containertypes/1" name="96 well plate">
+    <is-tube>false</is-tube>
+    <x-dimension>
+        <is-alpha>false</is-alpha>
+        <offset>1</offset>
+        <size>12</size>
+    </x-dimension>
+    <y-dimension>
+        <is-alpha>true</is-alpha>
+        <offset>0</offset>
+        <size>8</size>
+    </y-dimension>
+</ctp:container-type>

--- a/tests/fixtures/reception_control_wgs/containertypes/2.xml
+++ b/tests/fixtures/reception_control_wgs/containertypes/2.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ctp:container-type xmlns:ctp="http://genologics.com/ri/containertype" uri="http://127.0.0.1:8000/api/v2/containertypes/2" name="Tube">
+    <is-tube>true</is-tube>
+    <x-dimension>
+        <is-alpha>false</is-alpha>
+        <offset>1</offset>
+        <size>1</size>
+    </x-dimension>
+    <y-dimension>
+        <is-alpha>false</is-alpha>
+        <offset>1</offset>
+        <size>1</size>
+    </y-dimension>
+</ctp:container-type>

--- a/tests/fixtures/reception_control_wgs/processes/24-349794.xml
+++ b/tests/fixtures/reception_control_wgs/processes/24-349794.xml
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='utf-8'?>
+<prc:process xmlns:prc="http://genologics.com/ri/process" uri="http://127.0.0.1:8000/api/v2/processes/24-349794" limsid="24-349794">
+    <type uri="http://127.0.0.1:8000/api/v2/processtypes/679">CG002 - Reception Control</type>
+    <technician uri="http://127.0.0.1:8000/api/v2/researchers/1154">
+        <first-name>Karl</first-name>
+        <last-name>Svärd</last-name>
+    </technician>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10237A2PA1?state=2188186" uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10237A2PA1?state=2188186" limsid="ACC10237A2PA1" />
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2762637?state=2190591" output-generation-type="PerInput" output-type="ResultFile" limsid="92-2762637" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10237A2PA1?state=2188186" uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10237A2PA1?state=2188186" limsid="ACC10237A2PA1" />
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2762640?state=2190594" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2762640" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10237A2PA1?state=2188186" uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10237A2PA1?state=2188186" limsid="ACC10237A2PA1" />
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2762641?state=2190595" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2762641" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A8PA1?state=2188499" uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A8PA1?state=2188499" limsid="ACC10242A8PA1" />
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2762638?state=2190592" output-generation-type="PerInput" output-type="ResultFile" limsid="92-2762638" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A8PA1?state=2188499" uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A8PA1?state=2188499" limsid="ACC10242A8PA1" />
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2762640?state=2190594" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2762640" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A8PA1?state=2188499" uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A8PA1?state=2188499" limsid="ACC10242A8PA1" />
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2762641?state=2190595" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2762641" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10243A1PA1?state=2188502" uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10243A1PA1?state=2188502" limsid="ACC10243A1PA1" />
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2762639?state=2190593" output-generation-type="PerInput" output-type="ResultFile" limsid="92-2762639" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10243A1PA1?state=2188502" uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10243A1PA1?state=2188502" limsid="ACC10243A1PA1" />
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2762640?state=2190594" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2762640" />
+    </input-output-map>
+    <input-output-map>
+        <input post-process-uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10243A1PA1?state=2188502" uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10243A1PA1?state=2188502" limsid="ACC10243A1PA1" />
+        <output uri="http://127.0.0.1:8000/api/v2/artifacts/92-2762641?state=2190595" output-generation-type="PerAllInputs" output-type="ResultFile" limsid="92-2762641" />
+    </input-output-map>
+    <process-parameter name="copy orig well" />
+</prc:process>

--- a/tests/fixtures/reception_control_wgs/samples/ACC10237A2.xml
+++ b/tests/fixtures/reception_control_wgs/samples/ACC10237A2.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8'?>
+<smp:sample xmlns:smp="http://genologics.com/ri/sample" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/samples/ACC10237A2" limsid="ACC10237A2">
+    <name>2022-19139-03</name>
+    <date-received>2022-07-21</date-received>
+    <project limsid="ACC10237" uri="http://127.0.0.1:8000/api/v2/projects/ACC10237" />
+    <submitter uri="http://127.0.0.1:8000/api/v2/researchers/3">
+        <first-name>API</first-name>
+        <last-name>Access</last-name>
+    </submitter>
+    <artifact limsid="ACC10237A2PA1" uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10237A2PA1?state=2171036" />
+    <udf:field type="String" name="Comment">F0044355</udf:field>
+    <udf:field type="String" name="customer">cust002</udf:field>
+    <udf:field type="String" name="Data Analysis">mip-dna</udf:field>
+    <udf:field type="String" name="Sequencing Analysis">WGSPCFC030</udf:field>
+    <udf:field type="Date" name="Received at">2022-10-07</udf:field>
+    <udf:field type="String" name="tumor">no</udf:field>
+    <udf:field type="String" name="Source">blood</udf:field>
+    <udf:field type="String" name="Volume (uL)">50.0</udf:field>
+    <udf:field type="String" name="Data Delivery">scout</udf:field>
+    <udf:field type="String" name="Passed Initial QC">True</udf:field>
+    <udf:field type="String" name="familyID">F0044355</udf:field>
+    <udf:field type="String" name="Gender">M</udf:field>
+    <udf:field type="String" name="priority">standard</udf:field>
+    <udf:field type="String" name="Process only if QC OK">no</udf:field>
+    <udf:field type="Numeric" name="Reads missing (M)">650</udf:field>
+    <udf:field type="String" name="Original Container">2022-19139-03</udf:field>
+    <udf:field type="String" name="Original Well">1:1</udf:field>
+</smp:sample>

--- a/tests/fixtures/reception_control_wgs/samples/ACC10242A8.xml
+++ b/tests/fixtures/reception_control_wgs/samples/ACC10242A8.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='utf-8'?>
+<smp:sample xmlns:smp="http://genologics.com/ri/sample" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/samples/ACC10242A8" limsid="ACC10242A8">
+    <name>22242-I-1A</name>
+    <date-received>2022-07-21</date-received>
+    <project limsid="ACC10242" uri="http://127.0.0.1:8000/api/v2/projects/ACC10242" />
+    <submitter uri="http://127.0.0.1:8000/api/v2/researchers/3">
+        <first-name>API</first-name>
+        <last-name>Access</last-name>
+    </submitter>
+    <artifact limsid="ACC10242A8PA1" uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10242A8PA1?state=2171144" />
+    <udf:field type="String" name="Comment">2022-21987-03</udf:field>
+    <udf:field type="String" name="customer">cust003</udf:field>
+    <udf:field type="String" name="Data Analysis">mip-dna</udf:field>
+    <udf:field type="String" name="Sequencing Analysis">WGSPCFC030</udf:field>
+    <udf:field type="Date" name="Library Prep Finished">2022-09-29</udf:field>
+    <udf:field type="Date" name="Received at">2022-10-06</udf:field>
+    <udf:field type="String" name="tumor">no</udf:field>
+    <udf:field type="String" name="Source">blood</udf:field>
+    <udf:field type="String" name="Volume (uL)">80.0</udf:field>
+    <udf:field type="String" name="Data Delivery">scout</udf:field>
+    <udf:field type="Numeric" name="Level of Multiplexing">8</udf:field>
+    <udf:field type="String" name="Passed Initial QC">True</udf:field>
+    <udf:field type="String" name="Passed Library QC">True</udf:field>
+    <udf:field type="String" name="Quantity">2200</udf:field>
+    <udf:field type="String" name="familyID">22242</udf:field>
+    <udf:field type="String" name="Gender">M</udf:field>
+    <udf:field type="String" name="priority">standard</udf:field>
+    <udf:field type="String" name="Process only if QC OK">no</udf:field>
+    <udf:field type="Numeric" name="Reads missing (M)">650</udf:field>
+    <udf:field type="String" name="Original Container">2213347 C SciL OP_20220721_1419_5QNN</udf:field>
+    <udf:field type="String" name="Original Well">H:1</udf:field>
+</smp:sample>

--- a/tests/fixtures/reception_control_wgs/samples/ACC10243A1.xml
+++ b/tests/fixtures/reception_control_wgs/samples/ACC10243A1.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='utf-8'?>
+<smp:sample xmlns:smp="http://genologics.com/ri/sample" xmlns:udf="http://genologics.com/ri/userdefined" uri="http://127.0.0.1:8000/api/v2/samples/ACC10243A1" limsid="ACC10243A1">
+    <name>DNA-T-K10632-22</name>
+    <date-received>2022-07-21</date-received>
+    <project limsid="ACC10243" uri="http://127.0.0.1:8000/api/v2/projects/ACC10243" />
+    <submitter uri="http://127.0.0.1:8000/api/v2/researchers/3">
+        <first-name>API</first-name>
+        <last-name>Access</last-name>
+    </submitter>
+    <artifact limsid="ACC10243A1PA1" uri="http://127.0.0.1:8000/api/v2/artifacts/ACC10243A1PA1?state=2171471" />
+    <udf:field type="String" name="customer">cust143</udf:field>
+    <udf:field type="String" name="Data Analysis">balsamic</udf:field>
+    <udf:field type="String" name="Sequencing Analysis">WGSPCFS120</udf:field>
+    <udf:field type="Date" name="Received at">2022-10-07</udf:field>
+    <udf:field type="String" name="tumor">yes</udf:field>
+    <udf:field type="String" name="Source">tissue (fresh frozen)</udf:field>
+    <udf:field type="String" name="Volume (uL)">40.0</udf:field>
+    <udf:field type="String" name="Data Delivery">scout</udf:field>
+    <udf:field type="String" name="Passed Initial QC">True</udf:field>
+    <udf:field type="String" name="familyID">K10632-22WGS</udf:field>
+    <udf:field type="String" name="Gender">F</udf:field>
+    <udf:field type="String" name="priority">research</udf:field>
+    <udf:field type="String" name="Process only if QC OK">yes</udf:field>
+    <udf:field type="Numeric" name="Reads missing (M)">2400</udf:field>
+    <udf:field type="String" name="Original Container">YL037</udf:field>
+    <udf:field type="String" name="Original Well">A:1</udf:field>
+</smp:sample>


### PR DESCRIPTION
### Added
- New EPP to copy udf values from measurement to analyte.
- New flag for hamilton normalization EPP that lets you read udf values from measurement input objects. Effectively making it possible ot be used in QC steps.

New commands:
`lims -c ../config/genologics-stage.yaml epps -l ../copy_m_to_a_log -p 24-349777 udf copy measurement-to-analyte -au 'Output Container Barcode'`
`lims -c ../config/genologics-stage.yaml epps -l ../quantit_ham_log -p 24-349771  files hamilton barcode-file -f ../test_file  -b 'Buffer Volume' -v 'Volume (ul)' -m`

**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


