### PR TITLE
Add new Sample Sheet v2 functionalities

### DIFF
--- a/cg_lims/EPPs/files/base.py
+++ b/cg_lims/EPPs/files/base.py
@@ -8,6 +8,7 @@ from cg_lims.EPPs.files.pooling_map.make_pooling_map import pool_map
 from cg_lims.EPPs.files.placement_map.make_96well_placement_map import placement_map
 from cg_lims.EPPs.files.csv_for_kapa_truble_shooting.csv_for_kapa_debug import trouble_shoot_kapa
 from cg_lims.EPPs.files.barcode_tubes import make_barcode_csv
+from cg_lims.EPPs.files.sample_sheet.create_sample_sheet import create_sample_sheet
 
 
 @click.group(invoke_without_command=True)
@@ -23,3 +24,4 @@ files.add_command(placement_map)
 files.add_command(hamilton)
 files.add_command(trouble_shoot_kapa)
 files.add_command(make_barcode_csv)
+files.add_command(create_sample_sheet)

--- a/cg_lims/EPPs/files/sample_sheet/create_sample_sheet.py
+++ b/cg_lims/EPPs/files/sample_sheet/create_sample_sheet.py
@@ -1,0 +1,153 @@
+import re
+import logging
+import sys
+import click
+
+from typing import List, Optional, Dict
+from genologics.lims import Artifact, Process, Lims
+from cg_lims import options
+from cg_lims.exceptions import LimsError, InvalidValueError, MissingValueError
+from cg_lims.get.artifacts import get_artifacts
+from cg_lims.EPPs.files.sample_sheet.models import SampleSheetHeader, NovaSeqXRun, LaneSample
+
+
+LOG = logging.getLogger(__name__)
+
+
+def get_artifact_lane(artifact: Artifact) -> int:
+    """Parse out the lane where an artifact is placed"""
+    return int(artifact.location[1].split(":")[0])
+
+
+def get_non_pooled_artifacts(artifact: Artifact) -> List[Artifact]:
+    """Find the parent artifact of the sample. Should hold the reagent_label"""
+    artifacts = []
+
+    if len(artifact.samples) == 1:
+        artifacts.append(artifact)
+        return artifacts
+
+    for artifact_input in artifact.input_artifact_list():
+        artifacts.extend(get_non_pooled_artifacts(artifact_input))
+
+    return artifacts
+
+
+def get_reagent_label(artifact) -> Optional[str]:
+    """Get the first and only reagent label from an artifact"""
+    labels: List[str] = artifact.reagent_labels
+    if len(labels) > 1:
+        raise ValueError("Expecting at most one reagent label. Got ({}).".format(len(labels)))
+    return labels[0] if labels else None
+
+
+def get_index(lims: Lims, label: str) -> str:
+    """Parse out the sequence from a reagent label"""
+
+    reagent_types = lims.get_reagent_types(name=label)
+
+    if len(reagent_types) > 1:
+        raise ValueError("Expecting at most one reagent type. Got ({}).".format(len(reagent_types)))
+
+    try:
+        reagent_type = reagent_types.pop()
+    except IndexError:
+        return ""
+    sequence = reagent_type.sequence
+
+    match = re.match(r"^.+ \((.+)\)$", label)
+    if match:
+        assert match.group(1) == sequence
+
+    return sequence
+
+
+def get_sample_indexes(artifact: Artifact) -> List[str]:
+    reagent = get_reagent_label(artifact=artifact)
+    index_string = get_index(lims=artifact.lims, label=reagent)
+    return index_string.split("-")
+
+
+def sort_lanes(lane_artifacts: Dict[int, Artifact]) -> Dict[int, Artifact]:
+    return dict(sorted(lane_artifacts.items()))
+
+
+def get_lane_artifacts(process: Process) -> Dict[int, Artifact]:
+    artifacts = get_artifacts(process=process)
+    lane_artifacts = {}
+    for artifact in artifacts:
+        lane = get_artifact_lane(artifact=artifact)
+        lane_artifacts[lane] = artifact
+    return sort_lanes(lane_artifacts=lane_artifacts)
+
+
+def create_bcl_settings_section(run_settings: NovaSeqXRun) -> str:
+    return (
+        f"{SampleSheetHeader.BCL_SETTINGS_SECTION}\n"
+        f"SoftwareVersion,{run_settings.bclconvert_software_version}\n"
+        f"FastqCompressionFormat,{run_settings.fastq_compression_format}\n\n"
+    )
+
+
+def get_lane_sample_object(run_settings: NovaSeqXRun, lane: int, artifact: Artifact) -> LaneSample:
+    indexes = get_sample_indexes(artifact=artifact)
+    if len(indexes) == 2:
+        return LaneSample(
+            run_settings=run_settings,
+            lane=lane,
+            sample_id=artifact.samples[0].id,
+            index1=indexes[0],
+            index2=indexes[1],
+        )
+    elif len(indexes) == 1:
+        return LaneSample(
+            run_settings=run_settings,
+            lane=lane,
+            sample_id=artifact.samples[0],
+            index1=indexes[0],
+            index2=None,
+        )
+    else:
+        raise ValueError(f"Expecting 1 or 2 total indexes. Got ({len(indexes)}).")
+
+
+def create_bcl_data_section(run_settings: NovaSeqXRun) -> str:
+    section = f"{SampleSheetHeader.BCL_DATA_SECTION}\n"
+    section = section + run_settings.get_bcl_data_header()
+    lane_artifacts = get_lane_artifacts(run_settings.process)
+    for lane in lane_artifacts:
+        unpooled_artifacts = get_non_pooled_artifacts(lane_artifacts[lane])
+        for artifact in unpooled_artifacts:
+            lane_sample = get_lane_sample_object(
+                run_settings=run_settings, lane=lane, artifact=artifact
+            )
+            section = section + lane_sample.get_bclconversion_data()
+    return section
+
+
+def create_sample_sheet_from_process(process: Process) -> str:
+    run_settings = NovaSeqXRun(process=process)
+    return (
+        run_settings.create_file_header_section()
+        + run_settings.create_reads_section()
+        + create_bcl_settings_section(run_settings=run_settings)
+        + create_bcl_data_section(run_settings=run_settings)
+    )
+
+
+@click.command()
+@options.file_placeholder(help="File placeholder name.")
+@click.pass_context
+def create_sample_sheet(ctx, file: str):
+    LOG.info(f"Running {ctx.command_path} with params: {ctx.params}")
+
+    process = ctx.obj["process"]
+
+    try:
+        sample_sheet = create_sample_sheet_from_process(process=process)
+        run_name = process.udf.get("Experiment Name")
+        with open(f"{file}_samplesheet_{run_name}.csv", "w") as file:
+            file.write(sample_sheet)
+        click.echo("The file was successfully generated.")
+    except LimsError as e:
+        sys.exit(e.message)

--- a/cg_lims/EPPs/files/sample_sheet/create_sample_sheet.py
+++ b/cg_lims/EPPs/files/sample_sheet/create_sample_sheet.py
@@ -4,18 +4,23 @@ import sys
 import click
 
 from typing import List, Optional, Dict
-from genologics.lims import Artifact, Process, Lims
+from genologics.lims import Artifact, Process, Lims, ReagentType
 from cg_lims import options
 from cg_lims.exceptions import LimsError, InvalidValueError, MissingValueError
 from cg_lims.get.artifacts import get_artifacts
-from cg_lims.EPPs.files.sample_sheet.models import SampleSheetHeader, NovaSeqXRun, LaneSample
+from cg_lims.EPPs.files.sample_sheet.models import (
+    IndexSetup,
+    SampleSheetHeader,
+    NovaSeqXRun,
+    LaneSample,
+)
 
 
 LOG = logging.getLogger(__name__)
 
 
 def get_artifact_lane(artifact: Artifact) -> int:
-    ""Return the lane where an artifact is placed"""
+    """Return the lane where an artifact is placed"""
     return int(artifact.location[1].split(":")[0])
 
 
@@ -27,8 +32,8 @@ def get_non_pooled_artifacts(artifact: Artifact) -> List[Artifact]:
         artifacts.append(artifact)
         return artifacts
 
-    for artifact_input in artifact.input_artifact_list():
-        artifacts.extend(get_non_pooled_artifacts(artifact_input))
+    for artifact in artifact.input_artifact_list():
+        artifacts.extend(get_non_pooled_artifacts(artifact))
     return artifacts
 
 
@@ -36,44 +41,47 @@ def get_reagent_label(artifact) -> Optional[str]:
     """Return the first and only reagent label from an artifact"""
     labels: List[str] = artifact.reagent_labels
     if len(labels) > 1:
-        raise ValueError("Expecting at most one reagent label. Got ({}).".format(len(labels)))
+        raise ValueError(f"Expecting at most one reagent label. Got {len(labels)}.")
     return labels[0] if labels else None
 
 
-def get_index(lims: Lims, label: str) -> str:
-    """Parse out the sequence from a reagent label"""
+def get_reagent_index(lims: Lims, label: str) -> str:
+    """Return the index sequence from a given reagent label"""
 
-    reagent_types = lims.get_reagent_types(name=label)
+    reagent_types: List[ReagentType] = lims.get_reagent_types(name=label)
 
     if len(reagent_types) > 1:
-        raise ValueError("Expecting at most one reagent type. Got ({}).".format(len(reagent_types)))
+        raise ValueError(f"Expecting at most one reagent type. Got {len(reagent_types)}.")
 
     try:
         reagent_type = reagent_types.pop()
     except IndexError:
         return ""
-    sequence = reagent_type.sequence
+    sequence: str = reagent_type.sequence
 
     match = re.match(r"^.+ \((.+)\)$", label)
-    if match:
-        assert match.group(1) == sequence
+    if match and match.group(1) != sequence:
+        raise ValueError(f"Given reagent label name doesn't match its index sequence.")
 
     return sequence
 
 
 def get_sample_indexes(artifact: Artifact) -> List[str]:
-    reagent = get_reagent_label(artifact=artifact)
-    index_string = get_index(lims=artifact.lims, label=reagent)
-    return index_string.split("-")
+    """Return the indexes that the sample has been prepped with."""
+    reagent: str = get_reagent_label(artifact=artifact)
+    index_sequence: str = get_reagent_index(lims=artifact.lims, label=reagent)
+    return index_sequence.split("-")
 
 
 def sort_lanes(lane_artifacts: Dict[int, Artifact]) -> Dict[int, Artifact]:
+    """Return a sorted version of the same dictionary by lane number."""
     return dict(sorted(lane_artifacts.items()))
 
 
 def get_lane_artifacts(process: Process) -> Dict[int, Artifact]:
-    artifacts = get_artifacts(process=process)
-    lane_artifacts = {}
+    """Return a sorted dictionary consisting of all pools in a given step and their lane position."""
+    artifacts: List[Artifact] = get_artifacts(process=process)
+    lane_artifacts: Dict = {}
     for artifact in artifacts:
         lane = get_artifact_lane(artifact=artifact)
         lane_artifacts[lane] = artifact
@@ -81,6 +89,7 @@ def get_lane_artifacts(process: Process) -> Dict[int, Artifact]:
 
 
 def create_bcl_settings_section(run_settings: NovaSeqXRun) -> str:
+    """Return the BCLConvert_Settings section of the sample sheet."""
     return (
         f"{SampleSheetHeader.BCL_SETTINGS_SECTION}\n"
         f"SoftwareVersion,{run_settings.bclconvert_software_version}\n"
@@ -89,8 +98,9 @@ def create_bcl_settings_section(run_settings: NovaSeqXRun) -> str:
 
 
 def get_lane_sample_object(run_settings: NovaSeqXRun, lane: int, artifact: Artifact) -> LaneSample:
-    indexes = get_sample_indexes(artifact=artifact)
-    if len(indexes) == 2:
+    """Return LaneSample object representing the data of a lane-sample instance in the BCLConvert_Data section."""
+    indexes: List[str] = get_sample_indexes(artifact=artifact)
+    if len(indexes) == IndexSetup.DUAL_INDEX:
         return LaneSample(
             run_settings=run_settings,
             lane=lane,
@@ -98,7 +108,7 @@ def get_lane_sample_object(run_settings: NovaSeqXRun, lane: int, artifact: Artif
             index1=indexes[0],
             index2=indexes[1],
         )
-    elif len(indexes) == 1:
+    elif len(indexes) == IndexSetup.SINGLE_INDEX:
         return LaneSample(
             run_settings=run_settings,
             lane=lane,
@@ -110,23 +120,25 @@ def get_lane_sample_object(run_settings: NovaSeqXRun, lane: int, artifact: Artif
 
 
 def create_bcl_data_section(run_settings: NovaSeqXRun) -> str:
-    section : str = f"{SampleSheetHeader.BCL_DATA_SECTION}\n"
-    section = section + run_settings.get_bcl_data_header()
-    lane_artifacts = get_lane_artifacts(run_settings.process)
+    """Return the BCLConvert_Data section of the sample sheet."""
+    section: str = f"{SampleSheetHeader.BCL_DATA_SECTION}\n"
+    section = section + run_settings.get_bcl_data_header_row()
+    lane_artifacts: Dict[int, Artifact] = get_lane_artifacts(process=run_settings.process)
     for lane in lane_artifacts:
-        unpooled_artifacts = get_non_pooled_artifacts(lane_artifacts[lane])
+        unpooled_artifacts: List[Artifact] = get_non_pooled_artifacts(artifact=lane_artifacts[lane])
         for artifact in unpooled_artifacts:
             lane_sample = get_lane_sample_object(
                 run_settings=run_settings, lane=lane, artifact=artifact
             )
-            section = section + lane_sample.get_bclconversion_data()
+            section = section + lane_sample.get_bclconversion_data_row()
     return section
 
 
 def create_sample_sheet_from_process(process: Process) -> str:
+    """Return the sample sheet content from a given sequencing run set-up process."""
     run_settings: NovaSeqXRun = NovaSeqXRun(process=process)
     return (
-        run_settings.create_file_header_section()
+        run_settings.create_head_section()
         + run_settings.create_reads_section()
         + create_bcl_settings_section(run_settings=run_settings)
         + create_bcl_data_section(run_settings=run_settings)
@@ -137,15 +149,16 @@ def create_sample_sheet_from_process(process: Process) -> str:
 @options.file_placeholder(help="File placeholder name.")
 @click.pass_context
 def create_sample_sheet(ctx, file: str):
+    """Create a sample sheet .csv file from a sequencing set-up step."""
     LOG.info(f"Running {ctx.command_path} with params: {ctx.params}")
 
     process = ctx.obj["process"]
 
     try:
-        sample_sheet = create_sample_sheet_from_process(process=process)
+        sample_sheet_content: str = create_sample_sheet_from_process(process=process)
         run_name: str = process.udf.get("Experiment Name")
         with open(f"{file}_samplesheet_{run_name}.csv", "w") as file:
-            file.write(sample_sheet)
+            file.write(sample_sheet_content)
         click.echo("The file was successfully generated.")
     except LimsError as e:
         sys.exit(e.message)

--- a/cg_lims/EPPs/files/sample_sheet/create_sample_sheet.py
+++ b/cg_lims/EPPs/files/sample_sheet/create_sample_sheet.py
@@ -15,13 +15,13 @@ LOG = logging.getLogger(__name__)
 
 
 def get_artifact_lane(artifact: Artifact) -> int:
-    """Parse out the lane where an artifact is placed"""
+    ""Return the lane where an artifact is placed"""
     return int(artifact.location[1].split(":")[0])
 
 
 def get_non_pooled_artifacts(artifact: Artifact) -> List[Artifact]:
-    """Find the parent artifact of the sample. Should hold the reagent_label"""
-    artifacts = []
+    """Return the parent artifact of the sample. Should hold the reagent_label"""
+    artifacts: List[Artifact] = []
 
     if len(artifact.samples) == 1:
         artifacts.append(artifact)
@@ -29,12 +29,11 @@ def get_non_pooled_artifacts(artifact: Artifact) -> List[Artifact]:
 
     for artifact_input in artifact.input_artifact_list():
         artifacts.extend(get_non_pooled_artifacts(artifact_input))
-
     return artifacts
 
 
 def get_reagent_label(artifact) -> Optional[str]:
-    """Get the first and only reagent label from an artifact"""
+    """Return the first and only reagent label from an artifact"""
     labels: List[str] = artifact.reagent_labels
     if len(labels) > 1:
         raise ValueError("Expecting at most one reagent label. Got ({}).".format(len(labels)))
@@ -107,12 +106,11 @@ def get_lane_sample_object(run_settings: NovaSeqXRun, lane: int, artifact: Artif
             index1=indexes[0],
             index2=None,
         )
-    else:
-        raise ValueError(f"Expecting 1 or 2 total indexes. Got ({len(indexes)}).")
+    raise ValueError(f"Expecting 1 or 2 total indexes. Got ({len(indexes)}).")
 
 
 def create_bcl_data_section(run_settings: NovaSeqXRun) -> str:
-    section = f"{SampleSheetHeader.BCL_DATA_SECTION}\n"
+    section : str = f"{SampleSheetHeader.BCL_DATA_SECTION}\n"
     section = section + run_settings.get_bcl_data_header()
     lane_artifacts = get_lane_artifacts(run_settings.process)
     for lane in lane_artifacts:
@@ -126,7 +124,7 @@ def create_bcl_data_section(run_settings: NovaSeqXRun) -> str:
 
 
 def create_sample_sheet_from_process(process: Process) -> str:
-    run_settings = NovaSeqXRun(process=process)
+    run_settings: NovaSeqXRun = NovaSeqXRun(process=process)
     return (
         run_settings.create_file_header_section()
         + run_settings.create_reads_section()
@@ -145,7 +143,7 @@ def create_sample_sheet(ctx, file: str):
 
     try:
         sample_sheet = create_sample_sheet_from_process(process=process)
-        run_name = process.udf.get("Experiment Name")
+        run_name: str = process.udf.get("Experiment Name")
         with open(f"{file}_samplesheet_{run_name}.csv", "w") as file:
             file.write(sample_sheet)
         click.echo("The file was successfully generated.")

--- a/cg_lims/EPPs/files/sample_sheet/models.py
+++ b/cg_lims/EPPs/files/sample_sheet/models.py
@@ -1,0 +1,138 @@
+from genologics.lims import Process
+from typing import Optional
+import logging
+
+LOG = logging.getLogger(__name__)
+
+
+class SampleSheetHeader:
+    FILE_SECTION: str = "[Header]"
+    READS_SECTION: str = "[Reads]"
+    SETTINGS_SECTION: str = "[Sequencing_Settings]"
+    BCL_SETTINGS_SECTION: str = "[BCLConvert_Settings]"
+    BCL_DATA_SECTION: str = "[BCLConvert_Data]"
+
+
+class NovaSeqXRun:
+    process_id: Process
+    run_name: str
+    file_format: int = 2
+    instrument_type: str
+    instrument_platform: str
+    index_orientation: str
+    read_1_cycles: int
+    read_2_cycles: Optional[int]
+    index_1_cycles: Optional[int]
+    index_2_cycles: Optional[int]
+    override_cycles: Optional[bool] = True
+    bclconvert_software_version: str
+    bclconvert_app_version: str
+    fastq_compression_format: str
+    trim_adapters: Optional[bool] = False
+
+    def __init__(self, process):
+        self.process = process
+        self.run_name = process.udf.get("Experiment Name")
+        self.instrument_type = "NovaSeqxPlus"
+        self.instrument_platform = "NovaSeqXSeries"
+        self.index_orientation = "Forward"
+        self.read_1_cycles = process.udf.get("Read 1 Cycles")
+        self.read_2_cycles = process.udf.get("Read 2 Cycles")
+        self.index_1_cycles = process.udf.get("Index Read 1")
+        self.index_2_cycles = process.udf.get("Index Read 2")
+        self.bclconvert_software_version = "4.1.5"
+        self.bclconvert_app_version = "4.1.5"
+        self.fastq_compression_format = "gzip"
+
+    def create_file_header_section(self) -> str:
+        return (
+            f"{SampleSheetHeader.FILE_SECTION},\n"
+            f"FileFormatVersion,{self.file_format}\n"
+            f"RunName,{self.run_name}\n"
+            f"InstrumentType,{self.instrument_type}\n"
+            f"InstrumentPlatform,{self.instrument_platform}\n"
+            f"IndexOrientation,{self.index_orientation}\n\n"
+        )
+
+    def create_reads_section(self) -> str:
+        return (
+            f"{SampleSheetHeader.READS_SECTION}\n"
+            f"Read1Cycles,{self.read_1_cycles}\n"
+            f"Read2Cycles,{self.read_2_cycles}\n"
+            f"Index1Cycles,{self.index_1_cycles}\n"
+            f"Index2Cycles,{self.index_2_cycles}\n\n"
+        )
+
+    def get_bcl_data_header(self) -> str:
+        base_header = "Lane,Sample_ID,Index"
+        if self.index_2_cycles:
+            base_header = base_header + ",Index2"
+        if self.override_cycles:
+            base_header = base_header + ",OverrideCycles"
+        if self.trim_adapters:
+            base_header = base_header + ",AdapterRead1,AdapterRead2"
+        return base_header + "\n"
+
+
+class LaneSample:
+    run_settings: NovaSeqXRun
+    lane: int
+    sample_id: str
+    index_1: str
+    index_2: Optional[str] = None
+    adapter_read_1: Optional[str] = None
+    adapter_read_2: Optional[str] = None
+    barcode_mismatch_index_1: Optional[int] = None
+    barcode_mismatch_index_2: Optional[int] = None
+
+    def __init__(
+        self,
+        run_settings: NovaSeqXRun,
+        lane: int,
+        sample_id: str,
+        index1: str,
+        index2: Optional[str],
+    ):
+        self.run_settings = run_settings
+        self.lane = lane
+        self.sample_id = sample_id
+        self.index_1 = index1
+        if index2:
+            self.index_2 = index2
+
+    @staticmethod
+    def _get_index_override(
+        index_length: int,
+        index_cycles: int,
+        backwards: bool = False,
+    ):
+        diff = index_cycles - index_length
+        if diff > 0 and backwards:
+            return f"N{diff}I{index_length}"
+        elif diff > 0 and not backwards:
+            return f"I{index_length}N{diff}"
+        else:
+            return f"I{index_length}"
+
+    def get_override_cycles(self) -> str:
+        read_1_setting = f"Y{self.run_settings.read_1_cycles}"
+        read_2_setting = f"Y{self.run_settings.read_2_cycles}"
+        index_1_setting = self._get_index_override(
+            index_length=len(self.index_1),
+            index_cycles=self.run_settings.index_1_cycles,
+            backwards=False,
+        )
+        index_2_setting = self._get_index_override(
+            index_length=len(self.index_2),
+            index_cycles=self.run_settings.index_2_cycles,
+            backwards=True,
+        )
+        return f"{read_1_setting};{index_1_setting};{index_2_setting};{read_2_setting}"
+
+    def get_bclconversion_data(self) -> str:
+        line = f"{self.lane},{self.sample_id},{self.index_1},{self.index_2}"
+        if self.run_settings.override_cycles:
+            line = line + f",{self.get_override_cycles()}"
+        if self.adapter_read_1 or self.adapter_read_2:
+            line = line + f",{self.adapter_read_1},{self.adapter_read_2}"
+        return line + "\n"

--- a/cg_lims/EPPs/files/sample_sheet/models.py
+++ b/cg_lims/EPPs/files/sample_sheet/models.py
@@ -42,7 +42,7 @@ class NovaSeqXRun:
     index_2_cycles: Optional[int]
     override_cycles: Optional[bool] = True
     bclconvert_software_version: str
-    bclconvert_app_version: str
+    bclconvert_app_version: Optional[str]
     fastq_compression_format: str
     trim_adapters: Optional[bool] = False
 
@@ -56,9 +56,8 @@ class NovaSeqXRun:
         self.read_2_cycles: int = process.udf.get("Read 2 Cycles")
         self.index_1_cycles: int = process.udf.get("Index Read 1")
         self.index_2_cycles: int = process.udf.get("Index Read 2")
-        self.bclconvert_software_version: str = "4.1.5"
-        self.bclconvert_app_version: str = "4.1.5"
-        self.fastq_compression_format: str = "gzip"
+        self.bclconvert_software_version: str = process.udf.get("BCLConvert Software Version")
+        self.fastq_compression_format: str = process.udf.get("Compression Format")
 
     def create_head_section(self) -> str:
         """Return the [Head] section of the sample sheet."""

--- a/cg_lims/EPPs/files/sample_sheet/models.py
+++ b/cg_lims/EPPs/files/sample_sheet/models.py
@@ -106,13 +106,12 @@ class LaneSample:
         index_cycles: int,
         backwards: bool = False,
     ):
-        diff = index_cycles - index_length
+        diff: int = index_cycles - index_length
         if diff > 0 and backwards:
             return f"N{diff}I{index_length}"
         elif diff > 0 and not backwards:
             return f"I{index_length}N{diff}"
-        else:
-            return f"I{index_length}"
+        return f"I{index_length}"
 
     def get_override_cycles(self) -> str:
         read_1_setting = f"Y{self.run_settings.read_1_cycles}"


### PR DESCRIPTION
The new NovaSeq X machines require a sample sheet to start sequencing runs. And the plan is to do this from our lims.

### Added
- New EPP to create a sample sheet v2 from a sequencing set up step.
- New models to assist with sample sheet creation

### Changed


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


