### PR TITLE
Add new option to move-samples EPP

### DIFF
--- a/cg_lims/EPPs/move/move_samples.py
+++ b/cg_lims/EPPs/move/move_samples.py
@@ -46,7 +46,7 @@ def move_samples(
     if udf_values:
         filtered_artifacts = []
         for udf_value in udf_values:
-            filtered_artifacts.append(filter_artifacts(artifacts, udf, udf_value))
+            filtered_artifacts.extend(filter_artifacts(artifacts, udf, udf_value))
     else:
         filtered_artifacts = filter_artifacts(artifacts, udf, True)
 

--- a/cg_lims/EPPs/move/move_samples.py
+++ b/cg_lims/EPPs/move/move_samples.py
@@ -2,7 +2,7 @@
 
 import logging
 import sys
-from typing import Optional
+from typing import Optional, List
 
 import click
 
@@ -18,15 +18,23 @@ LOG = logging.getLogger(__name__)
 @options.workflow_id(help="Destination workflow id.")
 @options.stage_id(help="Destination stage id.")
 @options.udf(help="UDF that will tell which artifacts to move.")
+@options.udf_values(help="UDF values that will be filtered on.")
 @options.input(
     help="Use this flag if you want to queue the input artifacts of the current process. Default is to queue the "
     "output artifacts (analytes) of the process. "
 )
 @click.pass_context
-def move_samples(ctx, workflow_id: str, stage_id: str, udf: Optional[str], input: bool):
-    """Script to move aritfats to another stage.
+def move_samples(
+    ctx,
+    workflow_id: str,
+    stage_id: str,
+    udf: Optional[str],
+    udf_values: Optional[List[str]],
+    input: bool,
+):
+    """Script to move artifacts to another stage.
 
-    Queueing artifacts from the current process with <udf>==True, to stage with <stage-id>
+    Queueing artifacts from the current process with <udf> values equals any in <udf-values>, to stage with <stage-id>
     in workflow with <workflow-id>. Raising error if queuing fails.
 
     If udf is None all artifacts from the current step will be queued."""
@@ -35,7 +43,12 @@ def move_samples(ctx, workflow_id: str, stage_id: str, udf: Optional[str], input
     lims = ctx.obj["lims"]
 
     artifacts = get_artifacts(process=process, input=input)
-    filtered_artifacts = filter_artifacts(artifacts, udf, True)
+    if udf_values:
+        filtered_artifacts = []
+        for udf_value in udf_values:
+            filtered_artifacts.append(filter_artifacts(artifacts, udf, udf_value))
+    else:
+        filtered_artifacts = filter_artifacts(artifacts, udf, True)
 
     if not filtered_artifacts:
         LOG.info("No artifacts to queue.")

--- a/cg_lims/options.py
+++ b/cg_lims/options.py
@@ -326,8 +326,8 @@ def ignore_fail(
         is_flag=True,
         help=help,
     )
-  
-  
+
+
 def sample_volume_limit(help: str = "Set sample volume limit") -> click.option:
     return click.option("-svl", "--sample-volume-limit", required=False, help=help, type=float)
 
@@ -343,11 +343,25 @@ def keep_failed_flags(
     )
 
 
-def container_type( help: str = "Specific container type, Tube or Plate.", ) -> click.option:
+def container_type(
+    help: str = "Specific container type, Tube or Plate.",
+) -> click.option:
     return click.option(
         "-ct",
         "--container-type",
         required=False,
         multiple=False,
+        help=help,
+    )
+
+
+def udf_values(
+    help: str = "Possible UDF values",
+) -> click.option:
+    return click.option(
+        "-v",
+        "--values",
+        required=False,
+        multiple=True,
         help=help,
     )

--- a/cg_lims/options.py
+++ b/cg_lims/options.py
@@ -359,8 +359,8 @@ def udf_values(
     help: str = "Possible UDF values",
 ) -> click.option:
     return click.option(
-        "-v",
-        "--values",
+        "-uv",
+        "--udf-values",
         required=False,
         multiple=True,
         help=help,


### PR DESCRIPTION
### Added
- New option to the move samples EPP that will let you decide directly from the CLI which UDF values to filter artifacts on.


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


