### PR TITLE
Remove unused imports

### DIFF
--- a/cg_lims/EPPs/__init__.py
+++ b/cg_lims/EPPs/__init__.py
@@ -1,1 +1,0 @@
-from .base import epps

--- a/cg_lims/EPPs/arnold/__init__.py
+++ b/cg_lims/EPPs/arnold/__init__.py
@@ -1,1 +1,0 @@
-from .base import arnold_upload

--- a/cg_lims/EPPs/arnold/base.py
+++ b/cg_lims/EPPs/arnold/base.py
@@ -12,7 +12,6 @@ from cg_lims.EPPs.arnold.flow_cell import flow_cell
 @click.pass_context
 def arnold_upload(ctx):
     """Main load commands."""
-    pass
 
 
 arnold_upload.add_command(flow_cell)

--- a/cg_lims/EPPs/files/__init__.py
+++ b/cg_lims/EPPs/files/__init__.py
@@ -1,1 +1,0 @@
-from .base import files

--- a/cg_lims/EPPs/files/base.py
+++ b/cg_lims/EPPs/files/base.py
@@ -16,7 +16,6 @@ from cg_lims.EPPs.files.sample_sheet.create_sample_sheet import create_sample_sh
 @click.pass_context
 def files(ctx):
     """Main entry point of file commands"""
-    pass
 
 
 files.add_command(csv_well_to_udf)

--- a/cg_lims/EPPs/files/hamilton/base.py
+++ b/cg_lims/EPPs/files/hamilton/base.py
@@ -11,7 +11,6 @@ from cg_lims.EPPs.files.hamilton.buffer_exchange_twist_file import buffer_exchan
 @click.pass_context
 def hamilton(ctx):
     """Main entry point of hamilton file commands"""
-    pass
 
 
 hamilton.add_command(make_kapa_csv)

--- a/cg_lims/EPPs/files/hamilton/normalization_file.py
+++ b/cg_lims/EPPs/files/hamilton/normalization_file.py
@@ -10,7 +10,7 @@ from genologics.lims import Artifact
 from cg_lims import options
 from cg_lims.EPPs.files.hamilton.models import BarcodeFileRow
 from cg_lims.exceptions import LimsError, MissingUDFsError
-from cg_lims.files.manage_csv_files import build_csv, sort_csv, sort_csv_plate_and_tube
+from cg_lims.files.manage_csv_files import build_csv, sort_csv_plate_and_tube
 from cg_lims.get.artifacts import get_artifacts
 
 LOG = logging.getLogger(__name__)

--- a/cg_lims/EPPs/move/__init__.py
+++ b/cg_lims/EPPs/move/__init__.py
@@ -1,1 +1,0 @@
-from .base import move

--- a/cg_lims/EPPs/move/base.py
+++ b/cg_lims/EPPs/move/base.py
@@ -12,7 +12,6 @@ from cg_lims.EPPs.move.rerun_samples import rerun_samples
 @click.pass_context
 def move(ctx):
     """Main entry point of move commands"""
-    pass
 
 
 move.add_command(rerun_samples)

--- a/cg_lims/EPPs/move/rerun_samples.py
+++ b/cg_lims/EPPs/move/rerun_samples.py
@@ -5,7 +5,7 @@ import sys
 from typing import List
 
 import click
-from genologics.entities import Artifact, Process, Stage
+from genologics.entities import Artifact
 from genologics.lims import Lims
 
 from cg_lims import options

--- a/cg_lims/EPPs/qc/__init__.py
+++ b/cg_lims/EPPs/qc/__init__.py
@@ -1,1 +1,0 @@
-from .base import qc

--- a/cg_lims/EPPs/qc/base.py
+++ b/cg_lims/EPPs/qc/base.py
@@ -8,7 +8,6 @@ from cg_lims.EPPs.qc.set_qc_fail import set_qc_fail
 @click.pass_context
 def qc(ctx):
     """Main entry point of move commands"""
-    pass
 
 
 qc.add_command(set_qc_fail)

--- a/cg_lims/EPPs/udf/__init__.py
+++ b/cg_lims/EPPs/udf/__init__.py
@@ -1,1 +1,0 @@
-from .base import udf

--- a/cg_lims/EPPs/udf/base.py
+++ b/cg_lims/EPPs/udf/base.py
@@ -12,7 +12,6 @@ from cg_lims.EPPs.udf.check import check
 @click.pass_context
 def udf(ctx):
     """Main entry point of udf commands"""
-    pass
 
 
 udf.add_command(copy)

--- a/cg_lims/EPPs/udf/calculate/__init__.py
+++ b/cg_lims/EPPs/udf/calculate/__init__.py
@@ -1,1 +1,0 @@
-from .base import calculate

--- a/cg_lims/EPPs/udf/calculate/base.py
+++ b/cg_lims/EPPs/udf/calculate/base.py
@@ -38,7 +38,6 @@ from cg_lims.EPPs.udf.calculate.twist_qc_amount import twist_qc_amount
 @click.pass_context
 def calculate(ctx):
     """Main entry point of calculate commands"""
-    pass
 
 
 calculate.add_command(twist_pool)

--- a/cg_lims/EPPs/udf/calculate/calculate_water_volume_rna.py
+++ b/cg_lims/EPPs/udf/calculate/calculate_water_volume_rna.py
@@ -8,7 +8,7 @@ from typing import List
 import click
 from genologics.entities import Artifact
 
-from cg_lims.exceptions import InvalidValueError, LimsError, MissingUDFsError
+from cg_lims.exceptions import LimsError, MissingUDFsError
 from cg_lims.get.artifacts import get_artifacts
 
 LOG = logging.getLogger(__name__)

--- a/cg_lims/EPPs/udf/check/__init__.py
+++ b/cg_lims/EPPs/udf/check/__init__.py
@@ -1,1 +1,0 @@
-from .base import check

--- a/cg_lims/EPPs/udf/check/base.py
+++ b/cg_lims/EPPs/udf/check/base.py
@@ -10,7 +10,6 @@ from cg_lims.EPPs.udf.check.check_artifact_udfs import check_artifact_udfs
 @click.pass_context
 def check(ctx):
     """Main entry point of check commands"""
-    pass
 
 
 check.add_command(check_artifact_udfs)

--- a/cg_lims/EPPs/udf/copy/__init__.py
+++ b/cg_lims/EPPs/udf/copy/__init__.py
@@ -1,1 +1,0 @@
-from .base import copy

--- a/cg_lims/EPPs/udf/copy/artifact_to_artifact.py
+++ b/cg_lims/EPPs/udf/copy/artifact_to_artifact.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, Iterator
+from typing import List, Optional, Tuple
 from genologics.entities import Artifact
 from genologics.lims import Lims
 

--- a/cg_lims/EPPs/udf/copy/artifact_to_sample.py
+++ b/cg_lims/EPPs/udf/copy/artifact_to_sample.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
-import logging
 import sys
 
 import click
-from genologics.entities import Process
-from genologics.lims import Lims
 
 from cg_lims import options
 from cg_lims.exceptions import LimsError, MissingUDFsError

--- a/cg_lims/EPPs/udf/copy/base.py
+++ b/cg_lims/EPPs/udf/copy/base.py
@@ -19,7 +19,6 @@ from cg_lims.EPPs.udf.copy.measurement_to_analyte import measurement_to_analyte
 @click.pass_context
 def copy(ctx):
     """Main entry point of copy commands"""
-    pass
 
 
 copy.add_command(artifact_to_sample)

--- a/cg_lims/EPPs/udf/copy/original_well_to_sample.py
+++ b/cg_lims/EPPs/udf/copy/original_well_to_sample.py
@@ -2,9 +2,6 @@ import logging
 import sys
 import click
 
-from typing import List
-from genologics.entities import Process, Artifact
-from genologics.lims import Lims
 
 from cg_lims import options
 from cg_lims.exceptions import LimsError, InvalidValueError

--- a/cg_lims/EPPs/udf/copy/process_to_sample.py
+++ b/cg_lims/EPPs/udf/copy/process_to_sample.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python
-import logging
 import sys
 
 import click
-from genologics.entities import Process
-from genologics.lims import Lims
 
 from cg_lims import options
-from cg_lims.exceptions import LimsError, MissingUDFsError
 from cg_lims.get.samples import get_process_samples
 
 

--- a/cg_lims/EPPs/udf/copy/qc_to_sample.py
+++ b/cg_lims/EPPs/udf/copy/qc_to_sample.py
@@ -2,8 +2,6 @@ import logging
 import sys
 
 import click
-from genologics.entities import Process
-from genologics.lims import Lims
 
 from cg_lims import options
 from cg_lims.exceptions import LimsError, MissingUDFsError

--- a/cg_lims/EPPs/udf/set/__init__.py
+++ b/cg_lims/EPPs/udf/set/__init__.py
@@ -1,1 +1,0 @@
-from .base import set

--- a/cg_lims/EPPs/udf/set/base.py
+++ b/cg_lims/EPPs/udf/set/base.py
@@ -11,7 +11,6 @@ from cg_lims.EPPs.udf.set.novaseq_x_denaturation import novaseq_x_denaturation
 @click.pass_context
 def set(context: click.Context):
     """Main entry point of set commands"""
-    pass
 
 
 set.add_command(set_reads_missing_on_new_samples)

--- a/cg_lims/EPPs/udf/set/set_method.py
+++ b/cg_lims/EPPs/udf/set/set_method.py
@@ -2,7 +2,7 @@
 """
 import logging
 import sys
-from typing import List, Optional
+from typing import List
 
 import click
 
@@ -10,7 +10,7 @@ import requests
 from genologics.entities import Process
 
 from cg_lims import options
-from cg_lims.exceptions import LimsError, MissingUDFsError, AtlasResponseFailedError
+from cg_lims.exceptions import LimsError, AtlasResponseFailedError
 
 LOG = logging.getLogger(__name__)
 

--- a/cg_lims/commands/__init__.py
+++ b/cg_lims/commands/__init__.py
@@ -1,1 +1,0 @@
-from .base import cli

--- a/cg_lims/exceptions.py
+++ b/cg_lims/exceptions.py
@@ -13,19 +13,16 @@ class LimsError(Exception):
 class AtlasResponseFailedError(LimsError):
     """Raise when failing retrieve atlas response."""
 
-    pass
 
 
 class ArgumentError(LimsError):
     """Raise when failing retrieve atlas response."""
 
-    pass
 
 
 class QueueArtifactsError(LimsError):
     """Raise when failing to route artifacts."""
 
-    pass
 
 
 class MissingFileError(LimsError):
@@ -36,81 +33,68 @@ class DuplicateSampleError(LimsError):
     """Raise when you excpect one sample, but find more.
     Eg: Two pools in a run contain the same sample."""
 
-    pass
 
 
 class MissingArtifactError(LimsError):
     """Raise when searching for artifacts that don't exist.
     Eg: Found no artifact for sample X in process Y."""
 
-    pass
 
 
 class MissingProcessError(LimsError):
     """Raise when searching for process that don't exist.."""
 
-    pass
 
 
 class MissingSampleError(LimsError):
     """Raise when searching for samples that don't exist."""
 
-    pass
 
 
 class MissingUDFsError(LimsError):
     """Raise when searching for udfs that don't exist.
     Eg: Found no udf X on artifact Y."""
 
-    pass
 
 
 class ZeroReadsError(LimsError):
     """Raise when read count is unexpectedly zero."""
 
-    pass
 
 
 class LowAmountError(LimsError):
     """Raise when amount is low."""
 
-    pass
 
 
 class FailingQCError(LimsError):
     """Raise when qc fails"""
 
-    pass
 
 
 class MissingCgFieldError(LimsError):
     """Raise when field missing"""
 
-    pass
 
 
 class FileError(LimsError):
     """Raise when error with file"""
 
-    pass
 
 
 class MissingValueError(LimsError):
     """Raise when value missing"""
 
-    pass
 
 
 class InvalidValueError(LimsError):
     """Raise when a value is invalid"""
 
-    pass
 
 
 class CSVColumnError(LimsError):
     """Raise when handling errors with csv columns"""
 
-    pass
 
 
 class InsertError(LimsError):
@@ -123,4 +107,3 @@ class InsertError(LimsError):
 class HighConcentrationError(LimsError):
     """Raise when a value is invalid"""
 
-    pass

--- a/cg_lims/get/files.py
+++ b/cg_lims/get/files.py
@@ -1,12 +1,10 @@
 import pathlib
-from pathlib import Path
 from typing import Optional
 
 from genologics.config import BASEURI
-from genologics.entities import Artifact, Process
+from genologics.entities import Artifact
 from genologics.lims import Lims
 
-from cg_lims.exceptions import FileError
 
 
 def get_log_content(lims: Lims, file_id: str) -> str:

--- a/cg_lims/models/api/__init__.py
+++ b/cg_lims/models/api/__init__.py
@@ -1,1 +1,0 @@
-from .sample import Sample

--- a/cg_lims/models/api/master_steps/__init__.py
+++ b/cg_lims/models/api/master_steps/__init__.py
@@ -1,9 +1,0 @@
-from .buffer_exchange_v2 import BufferExchange
-from .pool_samples_twist_v2 import PoolsamplesforhybridizationTWIST
-from .bead_purification_twist_v2 import BeadPurificationTWIST
-from .hybridize_library_twist_v2 import HybridizeLibraryTWIST
-from .aliquot_samples_for_enzymatic_fragmentation_twist import (
-    AliquotsamplesforenzymaticfragmentationTWIST,
-)
-from .capture_and_wash_twist_v2 import CaptureandWashTWIST
-from .kapa_library_preparation_twist_v1 import KAPALibraryPreparation

--- a/cg_lims/models/api/master_steps/pool_samples_twist_v2.py
+++ b/cg_lims/models/api/master_steps/pool_samples_twist_v2.py
@@ -4,7 +4,7 @@ from genologics.entities import Artifact, Process
 from pydantic import Field, validator
 
 from cg_lims.models.api.master_steps.base_step import get_artifact_udf, get_artifact_name, BaseStep
-from cg_lims.get.artifacts import get_latest_analyte, get_artifacts
+from cg_lims.get.artifacts import get_latest_analyte
 
 
 class PoolsamplesforhybridizationTWIST(BaseStep):

--- a/cg_lims/models/arnold/__init__.py
+++ b/cg_lims/models/arnold/__init__.py
@@ -1,1 +1,0 @@
-from .sample import ArnoldSample

--- a/cg_lims/objects.py
+++ b/cg_lims/objects.py
@@ -1,6 +1,6 @@
 """Base cg_lims calss definitions
 """
-from typing import Optional, List
+from typing import Optional
 
 from genologics.entities import Artifact, Sample, Process
 from genologics.lims import Lims
@@ -16,7 +16,6 @@ from cg_lims.get.artifacts import (
     get_latest_analyte,
 )
 import logging
-from statistics import mean
 
 LOG = logging.getLogger(__name__)
 

--- a/cg_lims/put/queue.py
+++ b/cg_lims/put/queue.py
@@ -1,9 +1,8 @@
 import logging
-import pathlib
 from typing import List
 
 from genologics.config import BASEURI
-from genologics.entities import Artifact, Process, Sample
+from genologics.entities import Artifact
 from genologics.lims import Lims
 
 from cg_lims.get.ids import unique_list_of_ids

--- a/cg_lims/scripts/one_time_scripts/base.py
+++ b/cg_lims/scripts/one_time_scripts/base.py
@@ -11,7 +11,6 @@ from .fetch_tga_samples import fetch_tga_samples
 @click.pass_context
 def one_time(ctx):
     """Main load commands."""
-    pass
 
 
 one_time.add_command(update_arnold_preps)

--- a/cg_lims/scripts/one_time_scripts/load_arnold_flowcells.py
+++ b/cg_lims/scripts/one_time_scripts/load_arnold_flowcells.py
@@ -5,7 +5,6 @@ import click
 from genologics.lims import Lims
 import requests
 from requests import Response
-import json
 
 from cg_lims import options
 from cg_lims.EPPs.arnold.flow_cell import build_flow_cell_document

--- a/cg_lims/set/udfs.py
+++ b/cg_lims/set/udfs.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Iterator
+from typing import List, Tuple
 
 from genologics.entities import Artifact, Process
 

--- a/tests/EPPs/arnold/test_arnold_novaseq_standard.py
+++ b/tests/EPPs/arnold/test_arnold_novaseq_standard.py
@@ -1,4 +1,4 @@
-from genologics.entities import Process, Processtype
+from genologics.entities import Process
 
 from cg_lims.EPPs.arnold.sequencing import build_step_documents
 from cg_lims.models.arnold.base_step import BaseStep

--- a/tests/EPPs/files/test_make_kapa_csv.py
+++ b/tests/EPPs/files/test_make_kapa_csv.py
@@ -2,7 +2,6 @@ from tests.conftest import server
 from pathlib import Path
 
 from genologics.entities import Artifact
-from genologics.entities import Sample
 
 import pytest
 

--- a/tests/EPPs/udf/calculate/test_calculate_average_size_and_set_qc.py
+++ b/tests/EPPs/udf/calculate/test_calculate_average_size_and_set_qc.py
@@ -1,9 +1,8 @@
 import pytest
-from genologics.entities import Artifact, Process
+from genologics.entities import Process
 
 from cg_lims.EPPs.udf.calculate.calculate_average_size_and_set_qc import calculate_average_size, set_average_and_qc
-from cg_lims.exceptions import MissingUDFsError, MissingCgFieldError
-from cg_lims.set.udfs import copy_artifact_to_artifact
+from cg_lims.exceptions import MissingUDFsError
 from tests.conftest import server
 
 

--- a/tests/EPPs/udf/calculate/test_maf_calculate_volume.py
+++ b/tests/EPPs/udf/calculate/test_maf_calculate_volume.py
@@ -3,7 +3,6 @@ import logging
 
 import pytest
 from genologics.entities import Artifact
-from genologics.lims import Lims
 from pydantic import ValidationError
 
 from cg_lims.EPPs.udf.calculate.maf_calculate_volume import (

--- a/tests/EPPs/udf/copy/test_aggregate_qc_flags_and_copy_fields.py
+++ b/tests/EPPs/udf/copy/test_aggregate_qc_flags_and_copy_fields.py
@@ -1,8 +1,7 @@
 import pytest
-from genologics.entities import Artifact, Process
+from genologics.entities import Process
 
-from cg_lims.EPPs.udf.copy.aggregate_qc_flags_and_copy_fields import get_copy_tasks, copy_udfs
-from cg_lims.get.artifacts import get_artifacts
+from cg_lims.EPPs.udf.copy.aggregate_qc_flags_and_copy_fields import get_copy_tasks
 from cg_lims.exceptions import MissingUDFsError
 from tests.conftest import server
 

--- a/tests/EPPs/udf/copy/test_measurement_to_analyte.py
+++ b/tests/EPPs/udf/copy/test_measurement_to_analyte.py
@@ -1,8 +1,8 @@
 import pytest
-from genologics.entities import Artifact, Process
+from genologics.entities import Process
 
 from cg_lims.EPPs.udf.copy.measurement_to_analyte import copy_udfs_to_all_analytes
-from cg_lims.get.artifacts import get_artifacts, get_latest_analyte
+from cg_lims.get.artifacts import get_artifacts
 from cg_lims.exceptions import MissingUDFsError
 from tests.conftest import server
 

--- a/tests/EPPs/udf/set/test_qc_to_sample.py
+++ b/tests/EPPs/udf/set/test_qc_to_sample.py
@@ -1,9 +1,8 @@
 import pytest
-from genologics.entities import Artifact, Process
+from genologics.entities import Process
 
-from cg_lims.exceptions import MissingUDFsError, MissingCgFieldError
+from cg_lims.exceptions import MissingUDFsError
 from cg_lims.EPPs.udf.copy.qc_to_sample import artifacts_to_sample
-from cg_lims.set.udfs import copy_artifact_to_artifact
 from tests.conftest import server
 
 from cg_lims.get.artifacts import get_artifacts

--- a/tests/EPPs/udf/set/test_set_method.py
+++ b/tests/EPPs/udf/set/test_set_method.py
@@ -9,7 +9,6 @@ from tests.conftest import (
 
 import responses
 import requests
-import logging
 
 
 @pytest.fixture()

--- a/tests/commands/test_base.py
+++ b/tests/commands/test_base.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 from cg_lims.commands.base import cli

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-from typing import Optional
 
 from genologics.lims import Lims
 from genologics.entities import Artifact, Sample
@@ -11,7 +10,6 @@ import threading
 import time
 
 from limsmock.server import run_server
-from pydantic import BaseModel, Field
 
 from tests.fixtures.flowcell_document import FLOW_CELL_DOCUMENT
 


### PR DESCRIPTION
This PR removes all unused imports in the repository using
```bash
autoflake --remove-all-unused-imports -i -r .
```
### Fixed
- Remove all unused imports

This [version](https://semver.org/) is a:
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


