### PR TITLE
#401: Import Pydantic v1 module from v2

### DIFF
--- a/cg_lims/EPPs/files/csv_for_kapa_truble_shooting/models.py
+++ b/cg_lims/EPPs/files/csv_for_kapa_truble_shooting/models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from cg_lims.models.api.master_steps import HybridizeLibraryTWIST
 

--- a/cg_lims/EPPs/files/hamilton/models.py
+++ b/cg_lims/EPPs/files/hamilton/models.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from genologics.entities import Artifact
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 
 class CovidPrepFileRow(BaseModel):

--- a/cg_lims/EPPs/files/placement_map/models.py
+++ b/cg_lims/EPPs/files/placement_map/models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class PlacementMapHeader(BaseModel):

--- a/cg_lims/EPPs/files/pooling_map/models.py
+++ b/cg_lims/EPPs/files/pooling_map/models.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class PlacementMapHeader(BaseModel):

--- a/cg_lims/EPPs/udf/calculate/maf_calculate_volume.py
+++ b/cg_lims/EPPs/udf/calculate/maf_calculate_volume.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 
 import click
 from genologics.entities import Artifact
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 from cg_lims.exceptions import LimsError
 from cg_lims.get.artifacts import get_artifacts

--- a/cg_lims/models/api/master_steps/aliquot_samples_for_enzymatic_fragmentation_twist.py
+++ b/cg_lims/models/api/master_steps/aliquot_samples_for_enzymatic_fragmentation_twist.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from genologics.entities import Artifact, Process
-from pydantic import Field, validator
+from pydantic.v1 import Field, validator
 
 from cg_lims.models.api.master_steps.base_step import (
     get_artifact_udf,

--- a/cg_lims/models/api/master_steps/base_step.py
+++ b/cg_lims/models/api/master_steps/base_step.py
@@ -1,5 +1,5 @@
 from genologics.lims import Lims
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 def get_artifact_udf(artifact, udf):

--- a/cg_lims/models/api/master_steps/bead_purification_twist_v2.py
+++ b/cg_lims/models/api/master_steps/bead_purification_twist_v2.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from genologics.entities import Artifact
-from pydantic import Field, validator
+from pydantic.v1 import Field, validator
 
 from cg_lims.models.api.master_steps.base_step import get_artifact_udf, BaseStep
 from cg_lims.get.artifacts import get_latest_analyte

--- a/cg_lims/models/api/master_steps/buffer_exchange_v2.py
+++ b/cg_lims/models/api/master_steps/buffer_exchange_v2.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from genologics.entities import Artifact
-from pydantic import Field, validator
+from pydantic.v1 import Field, validator
 
 from cg_lims.models.api.master_steps.base_step import get_artifact_udf, BaseStep
 from cg_lims.get.artifacts import get_latest_analyte

--- a/cg_lims/models/api/master_steps/capture_and_wash_twist_v2.py
+++ b/cg_lims/models/api/master_steps/capture_and_wash_twist_v2.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from genologics.entities import Artifact, Process
-from pydantic import Field, validator
+from pydantic.v1 import Field, validator
 
 from cg_lims.models.api.master_steps.base_step import BaseStep, get_process_udf
 from cg_lims.get.artifacts import get_latest_analyte

--- a/cg_lims/models/api/master_steps/hybridize_library_twist_v2.py
+++ b/cg_lims/models/api/master_steps/hybridize_library_twist_v2.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from genologics.entities import Artifact, Process
-from pydantic import Field, validator
+from pydantic.v1 import Field, validator
 
 from cg_lims.models.api.master_steps.base_step import (
     get_artifact_udf,

--- a/cg_lims/models/api/master_steps/kapa_library_preparation_twist_v1.py
+++ b/cg_lims/models/api/master_steps/kapa_library_preparation_twist_v1.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from genologics.entities import Artifact, Process
-from pydantic import Field, validator
+from pydantic.v1 import Field, validator
 
 from cg_lims.models.api.master_steps.base_step import (
     get_artifact_udf,

--- a/cg_lims/models/api/master_steps/pool_samples_twist_v2.py
+++ b/cg_lims/models/api/master_steps/pool_samples_twist_v2.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from genologics.entities import Artifact, Process
-from pydantic import Field, validator
+from pydantic.v1 import Field, validator
 
 from cg_lims.models.api.master_steps.base_step import get_artifact_udf, get_artifact_name, BaseStep
 from cg_lims.get.artifacts import get_latest_analyte, get_artifacts

--- a/cg_lims/models/api/sample.py
+++ b/cg_lims/models/api/sample.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 import datetime as dt
 from typing import Optional
 import logging

--- a/cg_lims/models/arnold/base_step.py
+++ b/cg_lims/models/arnold/base_step.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Optional
-from pydantic import Field, BaseModel, validator
+from pydantic.v1 import Field, BaseModel, validator
 from datetime import date, datetime
 
 LOG = logging.getLogger(__name__)

--- a/cg_lims/models/arnold/flow_cell.py
+++ b/cg_lims/models/arnold/flow_cell.py
@@ -1,7 +1,7 @@
 from typing import Optional, List
 from datetime import date, datetime
 
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 
 class Lane(BaseModel):

--- a/cg_lims/models/arnold/prep/microbial_prep/buffer_exchange.py
+++ b/cg_lims/models/arnold/prep/microbial_prep/buffer_exchange.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 
 from cg_lims.models.arnold.base_step import BaseStep
 from cg_lims.objects import BaseAnalyte

--- a/cg_lims/models/arnold/prep/microbial_prep/microbial_library_prep_nextera.py
+++ b/cg_lims/models/arnold/prep/microbial_prep/microbial_library_prep_nextera.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 from cg_lims.models.arnold.base_step import BaseStep
 from cg_lims.objects import BaseAnalyte
 

--- a/cg_lims/models/arnold/prep/microbial_prep/normailzation_of_microbial_samples_for_sequencing.py
+++ b/cg_lims/models/arnold/prep/microbial_prep/normailzation_of_microbial_samples_for_sequencing.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Optional
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 from cg_lims.models.arnold.base_step import BaseStep
 from cg_lims.objects import BaseAnalyte
 

--- a/cg_lims/models/arnold/prep/microbial_prep/normalization_of_microbial_samples.py
+++ b/cg_lims/models/arnold/prep/microbial_prep/normalization_of_microbial_samples.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 
 from cg_lims.models.arnold.base_step import BaseStep
 from cg_lims.objects import BaseAnalyte

--- a/cg_lims/models/arnold/prep/microbial_prep/post_pcr_bead_purification.py
+++ b/cg_lims/models/arnold/prep/microbial_prep/post_pcr_bead_purification.py
@@ -2,8 +2,8 @@ import logging
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 
 from cg_lims.models.arnold.base_step import BaseStep
 from cg_lims.objects import BaseAnalyte

--- a/cg_lims/models/arnold/prep/microbial_prep/reception_control.py
+++ b/cg_lims/models/arnold/prep/microbial_prep/reception_control.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 from cg_lims.objects import BaseAnalyte
 from cg_lims.models.arnold.base_step import BaseStep
 

--- a/cg_lims/models/arnold/prep/rna/a_tailing_and_adapter_ligation.py
+++ b/cg_lims/models/arnold/prep/rna/a_tailing_and_adapter_ligation.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 
 from cg_lims.objects import BaseAnalyte
 from cg_lims.models.arnold.base_step import BaseStep

--- a/cg_lims/models/arnold/prep/rna/aliquot_samples_for_fragmentation.py
+++ b/cg_lims/models/arnold/prep/rna/aliquot_samples_for_fragmentation.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 
 from cg_lims.objects import BaseAnalyte
 from cg_lims.models.arnold.base_step import BaseStep

--- a/cg_lims/models/arnold/prep/rna/normalization_of_samples_for_sequencing.py
+++ b/cg_lims/models/arnold/prep/rna/normalization_of_samples_for_sequencing.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Optional
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 from cg_lims.models.arnold.base_step import BaseStep
 from cg_lims.objects import BaseAnalyte
 

--- a/cg_lims/models/arnold/prep/rna/reception_control.py
+++ b/cg_lims/models/arnold/prep/rna/reception_control.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 from cg_lims.objects import BaseAnalyte
 from cg_lims.models.arnold.base_step import BaseStep
 

--- a/cg_lims/models/arnold/prep/sars_cov_2_prep/library_preparation.py
+++ b/cg_lims/models/arnold/prep/sars_cov_2_prep/library_preparation.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 
 from cg_lims.objects import BaseAnalyte
 from cg_lims.models.arnold.base_step import BaseStep

--- a/cg_lims/models/arnold/prep/sars_cov_2_prep/pooling_and_cleanup.py
+++ b/cg_lims/models/arnold/prep/sars_cov_2_prep/pooling_and_cleanup.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 
 from cg_lims.objects import BaseAnalyte
 

--- a/cg_lims/models/arnold/prep/sars_cov_2_prep/reception_control.py
+++ b/cg_lims/models/arnold/prep/sars_cov_2_prep/reception_control.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 from cg_lims.objects import BaseAnalyte
 from cg_lims.models.arnold.base_step import BaseStep
 

--- a/cg_lims/models/arnold/prep/twist/aliquot_samples_for_enzymatic_fragmentation_twist.py
+++ b/cg_lims/models/arnold/prep/twist/aliquot_samples_for_enzymatic_fragmentation_twist.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic import Field, BaseModel
+from pydantic.v1 import Field, BaseModel
 
 from cg_lims.objects import BaseAnalyte
 from cg_lims.models.arnold.base_step import BaseStep

--- a/cg_lims/models/arnold/prep/twist/amplify_captured_libraries.py
+++ b/cg_lims/models/arnold/prep/twist/amplify_captured_libraries.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from genologics.lims import Lims
-from pydantic import Field, BaseModel
+from pydantic.v1 import Field, BaseModel
 from cg_lims.objects import BaseAnalyte
 from cg_lims.models.arnold.base_step import BaseStep
 

--- a/cg_lims/models/arnold/prep/twist/bead_purification_twist.py
+++ b/cg_lims/models/arnold/prep/twist/bead_purification_twist.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic import Field, BaseModel
+from pydantic.v1 import Field, BaseModel
 from cg_lims.objects import BaseAnalyte
 from cg_lims.models.arnold.base_step import BaseStep
 

--- a/cg_lims/models/arnold/prep/twist/buffer_exchange.py
+++ b/cg_lims/models/arnold/prep/twist/buffer_exchange.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic import Field, BaseModel
+from pydantic.v1 import Field, BaseModel
 
 from cg_lims.objects import BaseAnalyte
 

--- a/cg_lims/models/arnold/prep/twist/capture_and_wash_twist.py
+++ b/cg_lims/models/arnold/prep/twist/capture_and_wash_twist.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic import Field, BaseModel
+from pydantic.v1 import Field, BaseModel
 
 from cg_lims.objects import BaseAnalyte
 from cg_lims.models.arnold.base_step import BaseStep

--- a/cg_lims/models/arnold/prep/twist/enzymatic_fragmentation_twist.py
+++ b/cg_lims/models/arnold/prep/twist/enzymatic_fragmentation_twist.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic import Field, BaseModel
+from pydantic.v1 import Field, BaseModel
 
 from cg_lims.objects import BaseAnalyte
 from cg_lims.models.arnold.base_step import BaseStep

--- a/cg_lims/models/arnold/prep/twist/hybridize_library_twist.py
+++ b/cg_lims/models/arnold/prep/twist/hybridize_library_twist.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic import Field, BaseModel
+from pydantic.v1 import Field, BaseModel
 from cg_lims.objects import BaseAnalyte
 from cg_lims.models.arnold.base_step import BaseStep
 

--- a/cg_lims/models/arnold/prep/twist/kapa_library_preparation_twist.py
+++ b/cg_lims/models/arnold/prep/twist/kapa_library_preparation_twist.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from genologics.lims import Lims
-from pydantic import Field, BaseModel
+from pydantic.v1 import Field, BaseModel
 
 from cg_lims.models.arnold.base_step import BaseStep
 from cg_lims.objects import BaseAnalyte

--- a/cg_lims/models/arnold/prep/twist/normalization_of_samples_for_sequencing.py
+++ b/cg_lims/models/arnold/prep/twist/normalization_of_samples_for_sequencing.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Optional
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 from cg_lims.models.arnold.base_step import BaseStep
 from cg_lims.objects import BaseAnalyte
 

--- a/cg_lims/models/arnold/prep/twist/pool_samples_twist.py
+++ b/cg_lims/models/arnold/prep/twist/pool_samples_twist.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from genologics.lims import Lims
-from pydantic import Field, BaseModel
+from pydantic.v1 import Field, BaseModel
 from cg_lims.objects import BaseAnalyte
 
 from cg_lims.models.arnold.base_step import BaseStep

--- a/cg_lims/models/arnold/prep/twist/reception_control.py
+++ b/cg_lims/models/arnold/prep/twist/reception_control.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic import Field, BaseModel
+from pydantic.v1 import Field, BaseModel
 
 from cg_lims.objects import BaseAnalyte
 

--- a/cg_lims/models/arnold/prep/wgs/aliquot_sampels_for_covaris.py
+++ b/cg_lims/models/arnold/prep/wgs/aliquot_sampels_for_covaris.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 from cg_lims.objects import BaseAnalyte
 from cg_lims.models.arnold.base_step import BaseStep
 

--- a/cg_lims/models/arnold/prep/wgs/endrepair_size_selection_a_tailing_adapter_ligation.py
+++ b/cg_lims/models/arnold/prep/wgs/endrepair_size_selection_a_tailing_adapter_ligation.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 
 from cg_lims.objects import BaseAnalyte
 from cg_lims.models.arnold.base_step import BaseStep

--- a/cg_lims/models/arnold/prep/wgs/fragment_dna_truseq_dna.py
+++ b/cg_lims/models/arnold/prep/wgs/fragment_dna_truseq_dna.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 
 from cg_lims.objects import BaseAnalyte
 from cg_lims.models.arnold.base_step import BaseStep

--- a/cg_lims/models/arnold/prep/wgs/reception_control.py
+++ b/cg_lims/models/arnold/prep/wgs/reception_control.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 
 from cg_lims.objects import BaseAnalyte
 

--- a/cg_lims/models/arnold/sample.py
+++ b/cg_lims/models/arnold/sample.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Optional
-from pydantic import Field, validator
-from pydantic.main import BaseModel
+from pydantic.v1 import Field, validator
+from pydantic.v1.main import BaseModel
 from datetime import date, datetime
 
 

--- a/cg_lims/models/arnold/sequencing/bcl_conversion_and_demultiplexing.py
+++ b/cg_lims/models/arnold/sequencing/bcl_conversion_and_demultiplexing.py
@@ -2,8 +2,8 @@ from statistics import mean
 from typing import Optional, List
 
 from genologics.lims import Lims, Process, Artifact
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 
 from cg_lims.get.artifacts import get_artifacts
 from cg_lims.models.arnold.base_step import BaseStep

--- a/cg_lims/models/arnold/sequencing/define_run_format.py
+++ b/cg_lims/models/arnold/sequencing/define_run_format.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 
 from cg_lims.models.arnold.base_step import BaseStep
 from cg_lims.objects import BaseAnalyte

--- a/cg_lims/models/arnold/sequencing/standard_make_pool_and_denature.py
+++ b/cg_lims/models/arnold/sequencing/standard_make_pool_and_denature.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 
 from cg_lims.models.arnold.base_step import BaseStep
 from cg_lims.objects import BaseAnalyte

--- a/cg_lims/models/arnold/sequencing/standard_prepare_for_sequencing.py
+++ b/cg_lims/models/arnold/sequencing/standard_prepare_for_sequencing.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 
 from cg_lims.models.arnold.base_step import BaseStep
 from cg_lims.objects import BaseAnalyte

--- a/cg_lims/models/arnold/sequencing/xp_denature_and_examp.py
+++ b/cg_lims/models/arnold/sequencing/xp_denature_and_examp.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 
 from cg_lims.models.arnold.base_step import BaseStep
 from cg_lims.objects import BaseAnalyte

--- a/cg_lims/models/arnold/sequencing/xp_load_to_flowcell.py
+++ b/cg_lims/models/arnold/sequencing/xp_load_to_flowcell.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from genologics.lims import Lims
-from pydantic.main import BaseModel
-from pydantic import Field
+from pydantic.v1.main import BaseModel
+from pydantic.v1 import Field
 
 from cg_lims.models.arnold.base_step import BaseStep
 from cg_lims.objects import BaseAnalyte

--- a/cg_lims/models/context.py
+++ b/cg_lims/models/context.py
@@ -1,5 +1,5 @@
 from genologics.lims import Lims
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from cg_lims.status_db_api import StatusDBAPI
 
 

--- a/cg_lims/scripts/prepare_fixture.py
+++ b/cg_lims/scripts/prepare_fixture.py
@@ -4,7 +4,7 @@ from typing import List
 import click
 from genologics.entities import Entity
 from genologics.lims import Process
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class ProcessFixure(BaseModel):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 genologics # requires python < 3.9  - AttributeError: 'xml.etree.ElementTree.Element' object has no attribute 'getchildren'
 click
 PyYAML
-pydantic
+pydantic==1.10
 fastapi
 pandas
 gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 genologics # requires python < 3.9  - AttributeError: 'xml.etree.ElementTree.Element' object has no attribute 'getchildren'
 click
 PyYAML
-pydantic==1.10
+pydantic==1.*
 fastapi
 pandas
 gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 genologics # requires python < 3.9  - AttributeError: 'xml.etree.ElementTree.Element' object has no attribute 'getchildren'
 click
 PyYAML
-pydantic==1.*
+pydantic
 fastapi
 pandas
 gunicorn

--- a/tests/EPPs/udf/calculate/test_maf_calculate_volume.py
+++ b/tests/EPPs/udf/calculate/test_maf_calculate_volume.py
@@ -4,7 +4,7 @@ import logging
 import pytest
 from genologics.entities import Artifact
 from genologics.lims import Lims
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from cg_lims.EPPs.udf.calculate.maf_calculate_volume import (
     QC_FAILED,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import threading
 import time
 
 from limsmock.server import run_server
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from tests.fixtures.flowcell_document import FLOW_CELL_DOCUMENT
 


### PR DESCRIPTION
Pydantic just released a new major version. This PR updates the Pydantic imports to use v1 which is still available in the v2, this enables us to do an incremental migration in smaller PR:s. See https://docs.pydantic.dev/latest/migration/.

All instances of `from pydantic import ...` were replaced with `from pydantic.v1 import ...`

The tests are failing in the master branch and any new deploy will fail with runtime errors.

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


