### PR TITLE
397 consume sequencing metrics endpoint

### DIFF
--- a/cg_lims/models/sequencing_metrics.py
+++ b/cg_lims/models/sequencing_metrics.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class SequencingMetrics(BaseModel):
+    flow_cell_name: str
+    flow_cell_lane_number: int
+    sample_internal_id: str
+    sample_total_reads_in_lane: int
+    sample_base_fraction_passing_q30: float
+    sample_base_mean_quality_score: float
+    created_at: datetime

--- a/cg_lims/status_db_api.py
+++ b/cg_lims/status_db_api.py
@@ -1,20 +1,34 @@
-import json
-
 import requests
+from typing import List
+from urllib.parse import urljoin
 
 from cg_lims.exceptions import LimsError
+from cg_lims.models.sequencing_metrics import SequencingMetrics
 
 
-class StatusDBAPI(object):
-    def __init__(self, url=None):
-        self.url = url
+class StatusDBAPI:
+    def __init__(self, base_url):
+        self.base_url = base_url
 
-    def apptag(self, tag_name, key=None, entry_point="/applications"):
+    def _get(self, endpoint, key=None):
+        url = urljoin(self.base_url, endpoint)
         try:
-            res = requests.get(self.url + entry_point + "/" + tag_name)
+            response = requests.get(url)
+            response.raise_for_status()
+            data = response.json()
             if key:
-                return json.loads(res.text)[key]
-            else:
-                return json.loads(res.text)
-        except ConnectionError:
-            raise LimsError(message="No connection to clinical-api!")
+                return data.get(key)
+            return data
+        except requests.RequestException as e:
+            raise LimsError(f"Failed to get data from {url}, {e}")
+
+    def apptag(self, tag_name, key=None):
+        app_tag_endpoint: str = f"/applications/{tag_name}"
+        return self._get(app_tag_endpoint, key)
+
+    def get_sequencing_metrics_for_flow_cell(
+        self, flow_cell_name: str
+    ) -> List[SequencingMetrics]:
+        metrics_endpoint: str = f"/flowcells/{flow_cell_name}/sequencing_metrics"
+        metrics_data = self._get(metrics_endpoint)
+        return [SequencingMetrics.model_validate(metric) for metric in metrics_data]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,16 @@
-from typing import Optional
+from typing import Dict, List, Optional
 
 from genologics.lims import Lims
 from genologics.entities import Artifact, Sample
 from pathlib import Path
+from mock import Mock
 
 import pytest
 from click.testing import CliRunner
 
 import threading
 import time
+from cg_lims.status_db_api import StatusDBAPI
 
 from limsmock.server import run_server
 from pydantic.v1 import BaseModel, Field
@@ -172,3 +174,31 @@ def barcode_tubes_csv() -> str:
     file_path = "tests/fixtures/barcode_tubes_csv.txt"
     file = Path(file_path)
     return file.read_text()
+
+
+@pytest.fixture
+def status_db_api_client() -> StatusDBAPI:
+    return StatusDBAPI("http://testbaseurl.com")
+
+
+@pytest.fixture
+def sequencing_metrics_json() -> List[Dict]:
+    return [
+        {
+            "flow_cell_name": "test",
+            "flow_cell_lane_number": 1,
+            "sample_internal_id": "test",
+            "sample_total_reads_in_lane": 100,
+            "sample_base_fraction_passing_q30": 0.95,
+            "sample_base_mean_quality_score": 30.0,
+            "created_at": "2022-01-01T00:00:00",
+        }
+    ]
+
+
+@pytest.fixture
+def mock_sequencing_metrics_get_response(sequencing_metrics_json) -> Mock:
+    mock_response = Mock()
+    mock_response.json.return_value = sequencing_metrics_json
+    mock_response.raise_for_status.return_value = None
+    return mock_response

--- a/tests/test_status_db_api_client.py
+++ b/tests/test_status_db_api_client.py
@@ -1,0 +1,22 @@
+from typing import Dict, List
+from mock import Mock
+
+from cg_lims.models.sequencing_metrics import SequencingMetrics
+from cg_lims.status_db_api import StatusDBAPI
+
+
+def test_get_sequencing_metrics_for_flow_cell(
+    status_db_api_client: StatusDBAPI,
+    mock_sequencing_metrics_get_response: Mock,
+    sequencing_metrics_json: List[Dict],
+    mocker,
+):
+    # GIVEN a json response with sequencing metrics data
+    mocker.patch('requests.get', return_value=mock_sequencing_metrics_get_response)
+
+    # WHEN retrieving sequencing metrics for a flow cell
+    result = status_db_api_client.get_sequencing_metrics_for_flow_cell("flowcellname")
+
+    # THEN a list of the parsed sequencing metrics should be returned
+    sequencing_metrics = [SequencingMetrics.model_validate(data) for data in sequencing_metrics_json]
+    assert result == sequencing_metrics


### PR DESCRIPTION
This PR adds a method consuming the endpoint for retrieving sequencing metrics from the cg api.
The method will be used in the new script for validating the sequencing quality, part of project https://github.com/Clinical-Genomics/project-planning/issues/482 which aims to remove cgstats.

### Added
- Method for retrieving sequencing metrics to cg api client

This [version](https://semver.org/) is a:
- [ ] **MINOR** - when you add functionality in a backwards compatible manner

