### PR TITLE
Replace output type strings with enums

### DIFF
--- a/cg_lims/EPPs/arnold/flow_cell.py
+++ b/cg_lims/EPPs/arnold/flow_cell.py
@@ -7,7 +7,7 @@ import requests
 from requests import Response
 
 from cg_lims.exceptions import LimsError
-from cg_lims.get.artifacts import get_output_artifacts
+from cg_lims.get.artifacts import OutputGenerationType, OutputType, get_output_artifacts
 
 from cg_lims.models.arnold.flow_cell import FlowCell, Lane
 
@@ -36,9 +36,14 @@ def flow_cell(ctx):
     lims: Lims = ctx.obj["lims"]
     arnold_host: str = ctx.obj["arnold_host"]
     lanes = get_output_artifacts(
-        process=process, output_generation_type=["PerInput"], lims=lims, output_type="ResultFile"
+        process=process,
+        output_generation_types=[OutputGenerationType.PER_INPUT],
+        lims=lims,
+        output_type=OutputType.RESULT_FILE,
     )
-    flow_cell_document: FlowCell = build_flow_cell_document(process=process, lanes=lanes)
+    flow_cell_document: FlowCell = build_flow_cell_document(
+        process=process, lanes=lanes
+    )
     response: Response = requests.post(
         url=f"{arnold_host}/flow_cell",
         headers={"Content-Type": "application/json"},

--- a/cg_lims/get/artifacts.py
+++ b/cg_lims/get/artifacts.py
@@ -11,12 +11,12 @@ from enum import Enum
 LOG = logging.getLogger(__name__)
 
 
-class OutputType(Enum):
+class OutputType(str, Enum):
     ANALYTE = "Analyte"
     RESULT_FILE = "ResultFile"
 
 
-class OutputGenerationType(Enum):
+class OutputGenerationType(str, Enum):
     PER_INPUT = "PerInput"
     PER_REAGENT = "PerReagentLabel"
     PER_ALL_INPUTS = "PerAllInputs"

--- a/cg_lims/get/artifacts.py
+++ b/cg_lims/get/artifacts.py
@@ -6,8 +6,20 @@ from genologics.lims import Lims
 from cg_lims.exceptions import FileError, MissingArtifactError
 from datetime import datetime
 import logging
+from enum import Enum
 
 LOG = logging.getLogger(__name__)
+
+
+class OutputType(Enum):
+    ANALYTE = "Analyte"
+    RESULT_FILE = "ResultFile"
+
+
+class OutputGenerationType(Enum):
+    PER_INPUT = "PerInput"
+    PER_REAGENT = "PerReagentLabel"
+    PER_ALL_INPUTS = "PerAllInputs"
 
 
 def get_sample_artifact(lims: Lims, sample: Sample) -> Artifact:
@@ -27,15 +39,15 @@ def get_sample_artifact(lims: Lims, sample: Sample) -> Artifact:
 def get_output_artifacts(
     lims: Lims,
     process: Process,
-    output_type: Literal["ResultFile", "Analyte"],
-    output_generation_type: List[Literal["PerInput", "PerReagentLabel", "PerAllInputs"]],
+    output_type: OutputType,
+    output_generation_types: List[OutputGenerationType],
 ) -> List[Artifact]:
     """Get output 'artifacts' based on output_generation_type and output_type"""
 
     artifacts = [
         Artifact(lims, id=output["limsid"])
-        for input, output in process.input_output_maps
-        if output["output-generation-type"] in output_generation_type
+        for _, output in process.input_output_maps
+        if output["output-generation-type"] in output_generation_types
         and output["output-type"] == output_type
     ]
     return list(frozenset(artifacts))
@@ -56,22 +68,25 @@ def get_artifacts(
         return get_output_artifacts(
             lims=process.lims,
             process=process,
-            output_type="ResultFile",
-            output_generation_type=["PerInput"],
+            output_type=OutputType.RESULT_FILE,
+            output_generation_types=[OutputGenerationType.PER_INPUT],
         )
     elif reagent_label:
         return get_output_artifacts(
             lims=process.lims,
             process=process,
-            output_type="ResultFile",
-            output_generation_type=["PerReagentLabel"],
+            output_type=OutputType.RESULT_FILE,
+            output_generation_types=[OutputGenerationType.PER_REAGENT],
         )
     else:
         return get_output_artifacts(
             lims=process.lims,
             process=process,
-            output_type="Analyte",
-            output_generation_type=["PerInput", "PerAllInputs"],
+            output_type=OutputType.ANALYTE,
+            output_generation_types=[
+                OutputGenerationType.PER_INPUT,
+                OutputGenerationType.PER_ALL_INPUTS,
+            ],
         )
 
 
@@ -116,7 +131,10 @@ def get_latest_artifact(lims_artifacts: List[Artifact]) -> Artifact:
 
 
 def get_latest_analyte(
-    lims: Lims, sample_id: str, process_types: Optional[List[str]], sample_artifact: bool = False
+    lims: Lims,
+    sample_id: str,
+    process_types: Optional[List[str]],
+    sample_artifact: bool = False,
 ) -> Artifact:
     """Getting the most recently generated analyte by process_types and sample_id.
 

--- a/cg_lims/scripts/one_time_scripts/load_arnold_flowcells.py
+++ b/cg_lims/scripts/one_time_scripts/load_arnold_flowcells.py
@@ -9,7 +9,7 @@ import json
 
 from cg_lims import options
 from cg_lims.EPPs.arnold.flow_cell import build_flow_cell_document
-from cg_lims.get.artifacts import get_output_artifacts
+from cg_lims.get.artifacts import OutputGenerationType, OutputType, get_output_artifacts
 from cg_lims.models.arnold.flow_cell import FlowCell
 
 LOG = logging.getLogger(__name__)
@@ -32,9 +32,9 @@ def update_arnold_flow_cells(ctx, process_types: List[str]):
         try:
             lanes = get_output_artifacts(
                 process=process,
-                output_generation_type=["PerInput"],
+                output_generation_types=[OutputGenerationType.PER_INPUT],
                 lims=lims,
-                output_type="ResultFile",
+                output_type=OutputType.RESULT_FILE,
             )
             flow_cell_document: FlowCell = build_flow_cell_document(process=process, lanes=lanes)
             response: Response = requests.post(

--- a/tests/EPPs/arnold/test_arnold_load_flowcell.py
+++ b/tests/EPPs/arnold/test_arnold_load_flowcell.py
@@ -1,7 +1,7 @@
 from genologics.entities import Process
 
 from cg_lims.EPPs.arnold.flow_cell import build_flow_cell_document
-from cg_lims.get.artifacts import get_output_artifacts
+from cg_lims.get.artifacts import OutputGenerationType, OutputType, get_output_artifacts
 from cg_lims.models.arnold.flow_cell import FlowCell
 
 from tests.conftest import server
@@ -14,7 +14,10 @@ def test_load_flowcell(lims, flow_cell_fixture):
 
     process = Process(lims=lims, id="24-314318")
     lanes = get_output_artifacts(
-        process=process, output_generation_type=["PerInput"], lims=lims, output_type="ResultFile"
+        process=process,
+        output_generation_types=[OutputGenerationType.PER_INPUT],
+        lims=lims,
+        output_type=OutputType.RESULT_FILE,
     )
 
     # WHEN running build_flow_cell_document


### PR DESCRIPTION
This PR replaces all instances of magic strings for specifying the output types to instead use enum fields.

### Added
- Enum for OutputGenerationType
- Enum for OutputType

### Changed
- Signature of get_output_artifacts
- Calls to get_output_artifacts

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


