### PR TITLE
Rename method for retrieving application tags

### DIFF
--- a/cg_lims/EPPs/udf/calculate/get_missing_reads.py
+++ b/cg_lims/EPPs/udf/calculate/get_missing_reads.py
@@ -7,6 +7,7 @@ from requests.exceptions import ConnectionError
 
 from cg_lims.exceptions import LimsError, MissingCgFieldError, MissingUDFsError
 from cg_lims.get.artifacts import get_artifacts
+from cg_lims.status_db_api import StatusDBAPI
 
 LOG = logging.getLogger(__name__)
 
@@ -40,7 +41,7 @@ def check_control(artifact: Artifact) -> bool:
     return all(sample.udf.get("Control") == "negative" for sample in artifact.samples)
 
 
-def find_reruns(artifacts: list, status_db) -> None:
+def find_reruns(artifacts: list, status_db: StatusDBAPI) -> None:
     """
     Looking for artifacts to rerun.
     Negative control samples are never sent for rerun.
@@ -60,8 +61,8 @@ def find_reruns(artifacts: list, status_db) -> None:
             continue
 
         try:
-            target_amount_reads = status_db.apptag(tag_name=app_tag, key="target_reads")
-            guaranteed_fraction = 0.01 * status_db.apptag(
+            target_amount_reads = status_db.get_application_tag(tag_name=app_tag, key="target_reads")
+            guaranteed_fraction = 0.01 * status_db.get_application_tag(
                 tag_name=app_tag, key="percent_reads_guaranteed"
             )
         except ConnectionError:

--- a/cg_lims/EPPs/udf/set/set_samples_reads_missing.py
+++ b/cg_lims/EPPs/udf/set/set_samples_reads_missing.py
@@ -16,7 +16,7 @@ LOG = logging.getLogger(__name__)
 
 def get_target_amount(app_tag: str, status_db: StatusDBAPI) -> int:
     """Gets the target amount of reads from clinical-api"""
-    return status_db.apptag(tag_name=app_tag, key="target_reads")
+    return status_db.get_application_tag(tag_name=app_tag, key="target_reads")
 
 
 def set_reads_missing_on_sample(sample: Sample, status_db: StatusDBAPI) -> None:

--- a/cg_lims/status_db_api.py
+++ b/cg_lims/status_db_api.py
@@ -9,7 +9,7 @@ class StatusDBAPI(object):
     def __init__(self, url=None):
         self.url = url
 
-    def apptag(self, tag_name, key=None, entry_point="/applications"):
+    def get_application_tag(self, tag_name, key=None, entry_point="/applications"):
         try:
             res = requests.get(self.url + entry_point + "/" + tag_name)
             if key:

--- a/tests/EPPs/udf/set/test_set_samples_reads_missing.py
+++ b/tests/EPPs/udf/set/test_set_samples_reads_missing.py
@@ -22,12 +22,12 @@ def test_get_target_amount(mock_status_db, mock_get_udf, sample_1: Sample):
 
     # WHEN getting the target amount of reads via the StatusDBAPI
     mock_get_udf.return_value = test_app_tag
-    mock_status_db.apptag.return_value = 9_000_000
+    mock_status_db.get_application_tag.return_value = 9_000_000
     result = get_target_amount(test_app_tag, mock_status_db)
 
     # THEN the target amount of reads should be retrieved via the StatusDBAPI
     assert result == 9_000_000
-    assert mock_status_db.apptag.mock_calls == [
+    assert mock_status_db.get_application_tag.mock_calls == [
         mock.call(tag_name=test_app_tag, key="target_reads")
     ]
 


### PR DESCRIPTION
This PR renames a method in the `StatusDBAPI` to give it a more explicit name.

### Fixed
- Naming of method in StatusDBAPI

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


