### PR TITLE
Rename status db api

### DIFF
--- a/cg_lims/EPPs/udf/set/set_samples_reads_missing.py
+++ b/cg_lims/EPPs/udf/set/set_samples_reads_missing.py
@@ -9,17 +9,17 @@ from genologics.entities import Sample
 from cg_lims.exceptions import LimsError, MissingUDFsError
 from cg_lims.get.samples import get_process_samples
 from cg_lims.get.udfs import get_udf
-from cg_lims.status_db_api import StatusDBAPI
+from cg_lims.status_db_api import StatusDBAPIClient
 
 LOG = logging.getLogger(__name__)
 
 
-def get_target_amount(app_tag: str, status_db: StatusDBAPI) -> int:
+def get_target_amount(app_tag: str, status_db: StatusDBAPIClient) -> int:
     """Gets the target amount of reads from clinical-api"""
     return status_db.apptag(tag_name=app_tag, key="target_reads")
 
 
-def set_reads_missing_on_sample(sample: Sample, status_db: StatusDBAPI) -> None:
+def set_reads_missing_on_sample(sample: Sample, status_db: StatusDBAPIClient) -> None:
     """Sets the udf "Reads missing (M)" on a sample to the target amount of reads bases on the app tag"""
     app_tag = get_udf(sample, "Sequencing Analysis")
     target_amount = get_target_amount(app_tag, status_db)
@@ -27,7 +27,7 @@ def set_reads_missing_on_sample(sample: Sample, status_db: StatusDBAPI) -> None:
     sample.put()
 
 
-def set_reads_missing(samples: List[Sample], status_db: StatusDBAPI) -> None:
+def set_reads_missing(samples: List[Sample], status_db: StatusDBAPIClient) -> None:
     """Attempts to set the udf "Reads missing (M)" on all samples"""
     failed_samples_count = 0
     succeeded_samples_count = 0

--- a/cg_lims/EPPs/udf/set/set_samples_reads_missing.py
+++ b/cg_lims/EPPs/udf/set/set_samples_reads_missing.py
@@ -9,17 +9,17 @@ from genologics.entities import Sample
 from cg_lims.exceptions import LimsError, MissingUDFsError
 from cg_lims.get.samples import get_process_samples
 from cg_lims.get.udfs import get_udf
-from cg_lims.status_db_api import StatusDBAPIClient
+from cg_lims.status_db_api import CgClient
 
 LOG = logging.getLogger(__name__)
 
 
-def get_target_amount(app_tag: str, status_db: StatusDBAPIClient) -> int:
+def get_target_amount(app_tag: str, status_db: CgClient) -> int:
     """Gets the target amount of reads from clinical-api"""
     return status_db.apptag(tag_name=app_tag, key="target_reads")
 
 
-def set_reads_missing_on_sample(sample: Sample, status_db: StatusDBAPIClient) -> None:
+def set_reads_missing_on_sample(sample: Sample, status_db: CgClient) -> None:
     """Sets the udf "Reads missing (M)" on a sample to the target amount of reads bases on the app tag"""
     app_tag = get_udf(sample, "Sequencing Analysis")
     target_amount = get_target_amount(app_tag, status_db)
@@ -27,7 +27,7 @@ def set_reads_missing_on_sample(sample: Sample, status_db: StatusDBAPIClient) ->
     sample.put()
 
 
-def set_reads_missing(samples: List[Sample], status_db: StatusDBAPIClient) -> None:
+def set_reads_missing(samples: List[Sample], status_db: CgClient) -> None:
     """Attempts to set the udf "Reads missing (M)" on all samples"""
     failed_samples_count = 0
     succeeded_samples_count = 0

--- a/cg_lims/commands/base.py
+++ b/cg_lims/commands/base.py
@@ -8,7 +8,7 @@ from cg_lims import options
 # commands
 from cg_lims.EPPs import epps
 from cg_lims.scripts.base import scripts
-from cg_lims.status_db_api import StatusDBAPIClient
+from cg_lims.status_db_api import CgClient
 
 
 @click.group(invoke_without_command=True)
@@ -18,7 +18,7 @@ def cli(ctx, config):
     with open(config) as file:
         config_data = yaml.load(file, Loader=yaml.FullLoader)
     lims = Lims(config_data["BASEURI"], config_data["USERNAME"], config_data["PASSWORD"])
-    status_db = StatusDBAPIClient(config_data["CG_URL"])
+    status_db = CgClient(config_data["CG_URL"])
 
     ctx.ensure_object(dict)
     ctx.obj["lims"] = lims

--- a/cg_lims/commands/base.py
+++ b/cg_lims/commands/base.py
@@ -8,7 +8,7 @@ from cg_lims import options
 # commands
 from cg_lims.EPPs import epps
 from cg_lims.scripts.base import scripts
-from cg_lims.status_db_api import StatusDBAPI
+from cg_lims.status_db_api import StatusDBAPIClient
 
 
 @click.group(invoke_without_command=True)
@@ -18,7 +18,7 @@ def cli(ctx, config):
     with open(config) as file:
         config_data = yaml.load(file, Loader=yaml.FullLoader)
     lims = Lims(config_data["BASEURI"], config_data["USERNAME"], config_data["PASSWORD"])
-    status_db = StatusDBAPI(config_data["CG_URL"])
+    status_db = StatusDBAPIClient(config_data["CG_URL"])
 
     ctx.ensure_object(dict)
     ctx.obj["lims"] = lims

--- a/cg_lims/models/context.py
+++ b/cg_lims/models/context.py
@@ -1,11 +1,11 @@
 from genologics.lims import Lims
 from pydantic.v1 import BaseModel
-from cg_lims.status_db_api import StatusDBAPI
+from cg_lims.status_db_api import StatusDBAPIClient
 
 
 class EPPContextObject(BaseModel):
     lims: Lims
-    status_db: StatusDBAPI
+    status_db: StatusDBAPIClient
 
     class Config:
         arbitrary_types_allowed = True

--- a/cg_lims/models/context.py
+++ b/cg_lims/models/context.py
@@ -1,11 +1,11 @@
 from genologics.lims import Lims
 from pydantic.v1 import BaseModel
-from cg_lims.status_db_api import StatusDBAPIClient
+from cg_lims.status_db_api import CgClient
 
 
 class EPPContextObject(BaseModel):
     lims: Lims
-    status_db: StatusDBAPIClient
+    status_db: CgClient
 
     class Config:
         arbitrary_types_allowed = True

--- a/cg_lims/status_db_api.py
+++ b/cg_lims/status_db_api.py
@@ -5,7 +5,7 @@ import requests
 from cg_lims.exceptions import LimsError
 
 
-class StatusDBAPI(object):
+class StatusDBAPIClient(object):
     def __init__(self, url=None):
         self.url = url
 

--- a/cg_lims/status_db_api.py
+++ b/cg_lims/status_db_api.py
@@ -5,7 +5,7 @@ import requests
 from cg_lims.exceptions import LimsError
 
 
-class StatusDBAPIClient(object):
+class CgClient(object):
     def __init__(self, url=None):
         self.url = url
 

--- a/tests/EPPs/udf/set/test_set_samples_reads_missing.py
+++ b/tests/EPPs/udf/set/test_set_samples_reads_missing.py
@@ -12,7 +12,7 @@ from tests.conftest import server
 
 
 @mock.patch("cg_lims.get.udfs.get_udf")
-@mock.patch("cg_lims.status_db_api.StatusDBAPI")
+@mock.patch("cg_lims.status_db_api.StatusDBAPIClient")
 def test_get_target_amount(mock_status_db, mock_get_udf, sample_1: Sample):
     # GIVEN a sample with a udf "Sequencing Analysis" containing an app
     # tag
@@ -20,19 +20,19 @@ def test_get_target_amount(mock_status_db, mock_get_udf, sample_1: Sample):
     test_app_tag = "TESTAPPTAG"
     sample_1.udf["Sequencing Analysis"] = test_app_tag
 
-    # WHEN getting the target amount of reads via the StatusDBAPI
+    # WHEN getting the target amount of reads via the StatusDBAPIClient
     mock_get_udf.return_value = test_app_tag
     mock_status_db.apptag.return_value = 9_000_000
     result = get_target_amount(test_app_tag, mock_status_db)
 
-    # THEN the target amount of reads should be retrieved via the StatusDBAPI
+    # THEN the target amount of reads should be retrieved via the StatusDBAPIClient
     assert result == 9_000_000
     assert mock_status_db.apptag.mock_calls == [
         mock.call(tag_name=test_app_tag, key="target_reads")
     ]
 
 
-@mock.patch("cg_lims.status_db_api.StatusDBAPI")
+@mock.patch("cg_lims.status_db_api.StatusDBAPIClient")
 @mock.patch("cg_lims.EPPs.udf.set.set_samples_reads_missing.get_target_amount")
 @mock.patch("cg_lims.EPPs.udf.set.set_samples_reads_missing.get_udf")
 def test_set_reads_missing_on_sample(
@@ -56,7 +56,7 @@ def test_set_reads_missing_on_sample(
 @mock.patch(
     "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
 )
-@mock.patch("cg_lims.status_db_api.StatusDBAPI")
+@mock.patch("cg_lims.status_db_api.StatusDBAPIClient")
 def test_set_reads_missing_one_sample(
     mock_status_db, mock_set_reads_missing_on_sample, sample_1: Sample
 ):
@@ -73,7 +73,7 @@ def test_set_reads_missing_one_sample(
 @mock.patch(
     "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
 )
-@mock.patch("cg_lims.status_db_api.StatusDBAPI")
+@mock.patch("cg_lims.status_db_api.StatusDBAPIClient")
 def test_set_reads_missing_multiple_samples(
     mock_status_db, mock_set_reads_missing_on_sample, sample_1: Sample, sample_2: Sample
 ):
@@ -93,7 +93,7 @@ def test_set_reads_missing_multiple_samples(
 @mock.patch(
     "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
 )
-@mock.patch("cg_lims.status_db_api.StatusDBAPI")
+@mock.patch("cg_lims.status_db_api.StatusDBAPIClient")
 def test_set_reads_missing_one_sample_exception(
     mock_status_db,
     mock_set_reads_missing_on_sample,
@@ -118,7 +118,7 @@ def test_set_reads_missing_one_sample_exception(
 @mock.patch(
     "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
 )
-@mock.patch("cg_lims.status_db_api.StatusDBAPI")
+@mock.patch("cg_lims.status_db_api.StatusDBAPIClient")
 def test_set_reads_missing_multiple_samples_exception_on_first_sample(
     mock_status_db,
     mock_set_reads_missing_on_sample,
@@ -151,7 +151,7 @@ def test_set_reads_missing_multiple_samples_exception_on_first_sample(
 @mock.patch(
     "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
 )
-@mock.patch("cg_lims.status_db_api.StatusDBAPI")
+@mock.patch("cg_lims.status_db_api.StatusDBAPIClient")
 def test_set_reads_missing_multiple_samples_exception_on_second_sample(
     mock_status_db,
     mock_set_reads_missing_on_sample,
@@ -186,7 +186,7 @@ def test_set_reads_missing_multiple_samples_exception_on_second_sample(
 @mock.patch(
     "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
 )
-@mock.patch("cg_lims.status_db_api.StatusDBAPI")
+@mock.patch("cg_lims.status_db_api.StatusDBAPIClient")
 def test_set_reads_missing_multiple_samples_exception_on_both_samples(
     mock_status_db,
     mock_set_reads_missing_on_sample,

--- a/tests/EPPs/udf/set/test_set_samples_reads_missing.py
+++ b/tests/EPPs/udf/set/test_set_samples_reads_missing.py
@@ -12,7 +12,7 @@ from tests.conftest import server
 
 
 @mock.patch("cg_lims.get.udfs.get_udf")
-@mock.patch("cg_lims.status_db_api.StatusDBAPIClient")
+@mock.patch("cg_lims.status_db_api.CgClient")
 def test_get_target_amount(mock_status_db, mock_get_udf, sample_1: Sample):
     # GIVEN a sample with a udf "Sequencing Analysis" containing an app
     # tag
@@ -20,19 +20,19 @@ def test_get_target_amount(mock_status_db, mock_get_udf, sample_1: Sample):
     test_app_tag = "TESTAPPTAG"
     sample_1.udf["Sequencing Analysis"] = test_app_tag
 
-    # WHEN getting the target amount of reads via the StatusDBAPIClient
+    # WHEN getting the target amount of reads via the CgClient
     mock_get_udf.return_value = test_app_tag
     mock_status_db.apptag.return_value = 9_000_000
     result = get_target_amount(test_app_tag, mock_status_db)
 
-    # THEN the target amount of reads should be retrieved via the StatusDBAPIClient
+    # THEN the target amount of reads should be retrieved via the CgClient
     assert result == 9_000_000
     assert mock_status_db.apptag.mock_calls == [
         mock.call(tag_name=test_app_tag, key="target_reads")
     ]
 
 
-@mock.patch("cg_lims.status_db_api.StatusDBAPIClient")
+@mock.patch("cg_lims.status_db_api.CgClient")
 @mock.patch("cg_lims.EPPs.udf.set.set_samples_reads_missing.get_target_amount")
 @mock.patch("cg_lims.EPPs.udf.set.set_samples_reads_missing.get_udf")
 def test_set_reads_missing_on_sample(
@@ -56,7 +56,7 @@ def test_set_reads_missing_on_sample(
 @mock.patch(
     "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
 )
-@mock.patch("cg_lims.status_db_api.StatusDBAPIClient")
+@mock.patch("cg_lims.status_db_api.CgClient")
 def test_set_reads_missing_one_sample(
     mock_status_db, mock_set_reads_missing_on_sample, sample_1: Sample
 ):
@@ -73,7 +73,7 @@ def test_set_reads_missing_one_sample(
 @mock.patch(
     "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
 )
-@mock.patch("cg_lims.status_db_api.StatusDBAPIClient")
+@mock.patch("cg_lims.status_db_api.CgClient")
 def test_set_reads_missing_multiple_samples(
     mock_status_db, mock_set_reads_missing_on_sample, sample_1: Sample, sample_2: Sample
 ):
@@ -93,7 +93,7 @@ def test_set_reads_missing_multiple_samples(
 @mock.patch(
     "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
 )
-@mock.patch("cg_lims.status_db_api.StatusDBAPIClient")
+@mock.patch("cg_lims.status_db_api.CgClient")
 def test_set_reads_missing_one_sample_exception(
     mock_status_db,
     mock_set_reads_missing_on_sample,
@@ -118,7 +118,7 @@ def test_set_reads_missing_one_sample_exception(
 @mock.patch(
     "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
 )
-@mock.patch("cg_lims.status_db_api.StatusDBAPIClient")
+@mock.patch("cg_lims.status_db_api.CgClient")
 def test_set_reads_missing_multiple_samples_exception_on_first_sample(
     mock_status_db,
     mock_set_reads_missing_on_sample,
@@ -151,7 +151,7 @@ def test_set_reads_missing_multiple_samples_exception_on_first_sample(
 @mock.patch(
     "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
 )
-@mock.patch("cg_lims.status_db_api.StatusDBAPIClient")
+@mock.patch("cg_lims.status_db_api.CgClient")
 def test_set_reads_missing_multiple_samples_exception_on_second_sample(
     mock_status_db,
     mock_set_reads_missing_on_sample,
@@ -186,7 +186,7 @@ def test_set_reads_missing_multiple_samples_exception_on_second_sample(
 @mock.patch(
     "cg_lims.EPPs.udf.set.set_samples_reads_missing.set_reads_missing_on_sample"
 )
-@mock.patch("cg_lims.status_db_api.StatusDBAPIClient")
+@mock.patch("cg_lims.status_db_api.CgClient")
 def test_set_reads_missing_multiple_samples_exception_on_both_samples(
     mock_status_db,
     mock_set_reads_missing_on_sample,


### PR DESCRIPTION
This PR renames the `StatusDbAPI` class to `CgClient` to make it more explicit that it is a client for an api.

### Fixed
- Make name for client consuming the status db api more explicit

This [version](https://semver.org/) is a:
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


