### PR TITLE
Patch comparison for q30 threshold

### DIFF
--- a/cg_lims/EPPs/qc/sequencing_quality_checker.py
+++ b/cg_lims/EPPs/qc/sequencing_quality_checker.py
@@ -75,7 +75,7 @@ class SequencingQualityChecker:
 
     def _passes_quality_thresholds(self, q30_score: float, reads: int) -> bool:
         """Check if the provided metrics pass the minimum quality thresholds."""
-        passes_q30_threshold = q30_score >= self.q30_threshold
+        passes_q30_threshold = q30_score * 100 >= self.q30_threshold
         passes_read_threshold = reads >= self.READS_MIN_THRESHOLD
         return passes_q30_threshold and passes_read_threshold
 

--- a/cg_lims/EPPs/qc/sequencing_quality_checker.py
+++ b/cg_lims/EPPs/qc/sequencing_quality_checker.py
@@ -63,7 +63,7 @@ class SequencingQualityChecker:
             sample_id=metrics.sample_internal_id,
             lane=metrics.flow_cell_lane_number,
             reads=metrics.sample_total_reads_in_lane,
-            q30_score=metrics.sample_base_fraction_passing_q30,
+            q30_score=metrics.sample_base_fraction_passing_q30 * 100,
             passed_quality_control=passed_quality_control,
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,7 +289,7 @@ def novaseq_metrics_passing_thresholds_json(
         sample_ids=novaseq_sample_ids,
         lanes=novaseq_lanes,
         total_reads_in_lane=10000,
-        base_fraction_passing_q30=100,
+        base_fraction_passing_q30=0.95,
     )
 
 
@@ -315,7 +315,7 @@ def novaseq_metrics_failing_reads_json(
         sample_ids=novaseq_sample_ids,
         lanes=novaseq_lanes,
         total_reads_in_lane=0,
-        base_fraction_passing_q30=100,
+        base_fraction_passing_q30=0.95,
     )
 
 
@@ -328,7 +328,7 @@ def novaseq_metrics_two_failing(
         sample_ids=novaseq_sample_ids,
         lanes=novaseq_lanes,
         total_reads_in_lane=10000,
-        base_fraction_passing_q30=100,
+        base_fraction_passing_q30=0.95,
     )
 
     metrics[0]["sample_base_fraction_passing_q30"] = 0
@@ -365,7 +365,7 @@ def novaseq_metrics_missing_for_sample_in_lane(
         sample_ids=novaseq_sample_ids,
         lanes=novaseq_lanes,
         total_reads_in_lane=10000,
-        base_fraction_passing_q30=100,
+        base_fraction_passing_q30=0.95,
     )
     for metric in metrics:
         if (
@@ -390,7 +390,7 @@ def novaseq_missing_sample(
         sample_ids=novaseq_sample_ids,
         lanes=novaseq_lanes,
         total_reads_in_lane=10000,
-        base_fraction_passing_q30=100,
+        base_fraction_passing_q30=0.95,
     )
     return metrics
 


### PR DESCRIPTION
This PR fixes the comparison of the q30 score with the threshold. Updated the fixtures for the metrics with expected values for passing q30 scores.

q30 scores are reported as percentages for old flow cells in the metrics table, but as fractions for new flow cells. We will scale the old q30 metrics to fractions.

### Fixed
- q30 score threshold comparison in sequencing qc


This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


