### PR TITLE
Patch sequencing metrics model

### DIFF
--- a/cg_lims/EPPs/qc/sequencing_quality_checker.py
+++ b/cg_lims/EPPs/qc/sequencing_quality_checker.py
@@ -63,19 +63,19 @@ class SequencingQualityChecker:
             sample_id=metrics.sample_internal_id,
             lane=metrics.flow_cell_lane_number,
             reads=metrics.sample_total_reads_in_lane,
-            q30_score=metrics.sample_base_fraction_passing_q30 * 100,
+            q30_score=metrics.sample_base_percentage_passing_q30,
             passed_quality_control=passed_quality_control,
         )
 
     def _quality_control(self, metrics: SampleLaneSequencingMetrics) -> bool:
         return self._passes_quality_thresholds(
             reads=metrics.sample_total_reads_in_lane,
-            q30_score=metrics.sample_base_fraction_passing_q30,
+            q30_score=metrics.sample_base_percentage_passing_q30,
         )
 
     def _passes_quality_thresholds(self, q30_score: float, reads: int) -> bool:
         """Check if the provided metrics pass the minimum quality thresholds."""
-        passes_q30_threshold = q30_score * 100 >= self.q30_threshold
+        passes_q30_threshold = q30_score >= self.q30_threshold
         passes_read_threshold = reads >= self.READS_MIN_THRESHOLD
         return passes_q30_threshold and passes_read_threshold
 

--- a/cg_lims/models/sample_lane_sequencing_metrics.py
+++ b/cg_lims/models/sample_lane_sequencing_metrics.py
@@ -6,4 +6,4 @@ class SampleLaneSequencingMetrics(BaseModel):
     flow_cell_lane_number: int
     sample_internal_id: str
     sample_total_reads_in_lane: int
-    sample_base_fraction_passing_q30: float
+    sample_base_percentage_passing_q30: float

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,7 +218,7 @@ def sequencing_metrics_json() -> List[Dict]:
             "flow_cell_lane_number": 1,
             "sample_internal_id": "test",
             "sample_total_reads_in_lane": 100,
-            "sample_base_percentage_passing_q30": 0.95,
+            "sample_base_percentage_passing_q30": 95,
             "sample_base_mean_quality_score": 30.0,
         }
     ]
@@ -263,7 +263,7 @@ def generate_metrics_json(
     sample_ids: List[str],
     lanes: int,
     total_reads_in_lane: int,
-    base_fraction_passing_q30: float,
+    base_percentage_passing_q30: float,
 ) -> List[Dict]:
     metrics = []
     for sample_id in sample_ids:
@@ -273,7 +273,7 @@ def generate_metrics_json(
                 "flow_cell_lane_number": lane,
                 "sample_internal_id": sample_id,
                 "sample_total_reads_in_lane": total_reads_in_lane,
-                "sample_base_percentage_passing_q30": base_fraction_passing_q30,
+                "sample_base_percentage_passing_q30": base_percentage_passing_q30,
                 "created_at": dt.datetime.now().isoformat(),
             }
             metrics.append(metric)
@@ -289,7 +289,7 @@ def novaseq_metrics_passing_thresholds_json(
         sample_ids=novaseq_sample_ids,
         lanes=novaseq_lanes,
         total_reads_in_lane=10000,
-        base_fraction_passing_q30=0.95,
+        base_percentage_passing_q30=95,
     )
 
 
@@ -302,7 +302,7 @@ def novaseq_metrics_failing_q30_threshold_json(
         sample_ids=novaseq_sample_ids,
         lanes=novaseq_lanes,
         total_reads_in_lane=10000,
-        base_fraction_passing_q30=0,
+        base_percentage_passing_q30=0,
     )
 
 
@@ -315,7 +315,7 @@ def novaseq_metrics_failing_reads_json(
         sample_ids=novaseq_sample_ids,
         lanes=novaseq_lanes,
         total_reads_in_lane=0,
-        base_fraction_passing_q30=0.95,
+        base_percentage_passing_q30=95,
     )
 
 
@@ -328,7 +328,7 @@ def novaseq_metrics_two_failing(
         sample_ids=novaseq_sample_ids,
         lanes=novaseq_lanes,
         total_reads_in_lane=10000,
-        base_fraction_passing_q30=0.95,
+        base_percentage_passing_q30=95,
     )
 
     metrics[0]["sample_base_percentage_passing_q30"] = 0
@@ -365,7 +365,7 @@ def novaseq_metrics_missing_for_sample_in_lane(
         sample_ids=novaseq_sample_ids,
         lanes=novaseq_lanes,
         total_reads_in_lane=10000,
-        base_fraction_passing_q30=0.95,
+        base_percentage_passing_q30=95,
     )
     for metric in metrics:
         if (
@@ -390,7 +390,7 @@ def novaseq_missing_sample(
         sample_ids=novaseq_sample_ids,
         lanes=novaseq_lanes,
         total_reads_in_lane=10000,
-        base_fraction_passing_q30=0.95,
+        base_percentage_passing_q30=95,
     )
     return metrics
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,7 +218,7 @@ def sequencing_metrics_json() -> List[Dict]:
             "flow_cell_lane_number": 1,
             "sample_internal_id": "test",
             "sample_total_reads_in_lane": 100,
-            "sample_base_fraction_passing_q30": 0.95,
+            "sample_base_percentage_passing_q30": 0.95,
             "sample_base_mean_quality_score": 30.0,
         }
     ]
@@ -273,7 +273,7 @@ def generate_metrics_json(
                 "flow_cell_lane_number": lane,
                 "sample_internal_id": sample_id,
                 "sample_total_reads_in_lane": total_reads_in_lane,
-                "sample_base_fraction_passing_q30": base_fraction_passing_q30,
+                "sample_base_percentage_passing_q30": base_fraction_passing_q30,
                 "created_at": dt.datetime.now().isoformat(),
             }
             metrics.append(metric)
@@ -331,7 +331,7 @@ def novaseq_metrics_two_failing(
         base_fraction_passing_q30=0.95,
     )
 
-    metrics[0]["sample_base_fraction_passing_q30"] = 0
+    metrics[0]["sample_base_percentage_passing_q30"] = 0
     metrics[1]["sample_total_reads_in_lane"] = 0
 
     return metrics


### PR DESCRIPTION
We have updated the sequencing metrics in cg as to only contain percentages (as it was before in cgstats). This PR reflects the changes to the q30 metrics field and the logic for comparing it to the threshold. Part of resolving issue https://github.com/Clinical-Genomics/cg/issues/2350.

### Fixed
- q30 metrics naming
- Threshold comparison for q30 values

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

Blocked by https://github.com/Clinical-Genomics/cg/pull/2352
