### PR TITLE
Add Library Tube Strip ID info to sample sheet

### DIFF
--- a/cg_lims/EPPs/files/sample_sheet/create_sample_sheet.py
+++ b/cg_lims/EPPs/files/sample_sheet/create_sample_sheet.py
@@ -243,6 +243,7 @@ def create_sample_sheet_from_process(process: Process) -> str:
     return (
         run_settings.create_head_section()
         + run_settings.create_reads_section()
+        + run_settings.create_sequencing_settings_section()
         + create_bcl_settings_section(run_settings=run_settings)
         + create_bcl_data_section(run_settings=run_settings)
     )

--- a/cg_lims/EPPs/files/sample_sheet/models.py
+++ b/cg_lims/EPPs/files/sample_sheet/models.py
@@ -63,6 +63,7 @@ class NovaSeqXRun:
         self.index_2_cycles: int = process.udf.get("Index Read 2")
         self.bclconvert_software_version: str = process.udf.get("BCLConvert Software Version")
         self.fastq_compression_format: str = process.udf.get("Compression Format")
+        self.library_tube_id: str = process.udf.get("Library Tube Strip ID")
 
     def create_head_section(self) -> str:
         """Return the [Head] section of the sample sheet."""
@@ -83,6 +84,13 @@ class NovaSeqXRun:
             f"Read2Cycles,{self.read_2_cycles}\n"
             f"Index1Cycles,{self.index_1_cycles}\n"
             f"Index2Cycles,{self.index_2_cycles}\n\n"
+        )
+
+    def create_sequencing_settings_section(self) -> str:
+        """Return the [Sequencing_Settings] section of the sample sheet"""
+        return (
+            f"{SampleSheetHeader.SETTINGS_SECTION}\n"
+            f"InputContainerIdentifier,{self.library_tube_id}\n\n"
         )
 
     def get_bcl_data_header_row(self) -> str:
@@ -126,9 +134,7 @@ class LaneSample:
         self.index_1: str = index_1
         if index_2:
             self.index_2: str = index_2
-        # if barcode_mismatch_index_1:
         self.barcode_mismatch_index_1 = barcode_mismatch_index_1
-        # if barcode_mismatch_index_2:
         self.barcode_mismatch_index_2 = barcode_mismatch_index_2
 
     @staticmethod


### PR DESCRIPTION
### Added
- New sequencing settings section in the sample sheet 
- Added Library Tube Strip ID info to this section

**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


