### PR TITLE
Add option to skip BCL convert sections in sample sheet

### DIFF
--- a/cg_lims/EPPs/files/sample_sheet/create_sample_sheet.py
+++ b/cg_lims/EPPs/files/sample_sheet/create_sample_sheet.py
@@ -234,7 +234,7 @@ def create_bcl_data_section(run_settings: NovaSeqXRun) -> str:
                 all_indexes=pool_indexes,
             )
             section = section + lane_sample.get_bclconversion_data_row()
-    return f"{section}"
+    return section
 
 
 def create_sample_sheet_from_process(process: Process) -> str:

--- a/cg_lims/EPPs/files/sample_sheet/create_sample_sheet.py
+++ b/cg_lims/EPPs/files/sample_sheet/create_sample_sheet.py
@@ -220,7 +220,7 @@ def get_lane_sample_object(
 
 def create_bcl_data_section(run_settings: NovaSeqXRun) -> str:
     """Return the BCLConvert_Data section of the sample sheet."""
-    section: str = f"{SampleSheetHeader.BCL_DATA_SECTION}\n"
+    section: str = f"{SampleSheetHeader.BCL_DATA_SECTION}"
     section = section + run_settings.get_bcl_data_header_row()
     lane_artifacts: Dict[int, Artifact] = get_lane_artifacts(process=run_settings.process)
     for lane in lane_artifacts:
@@ -234,19 +234,24 @@ def create_bcl_data_section(run_settings: NovaSeqXRun) -> str:
                 all_indexes=pool_indexes,
             )
             section = section + lane_sample.get_bclconversion_data_row()
-    return section
+    return f"{section}"
 
 
 def create_sample_sheet_from_process(process: Process) -> str:
     """Return the sample sheet content from a given sequencing run set-up process."""
     run_settings: NovaSeqXRun = NovaSeqXRun(process=process)
-    return (
+    sample_sheet = (
         run_settings.create_head_section()
         + run_settings.create_reads_section()
         + run_settings.create_sequencing_settings_section()
-        + create_bcl_settings_section(run_settings=run_settings)
-        + create_bcl_data_section(run_settings=run_settings)
     )
+    if process.udf["DRAGEN Demultiplex"]:
+        sample_sheet = (
+            sample_sheet
+            + create_bcl_settings_section(run_settings=run_settings)
+            + create_bcl_data_section(run_settings=run_settings)
+        )
+    return sample_sheet
 
 
 @click.command()

--- a/cg_lims/EPPs/files/sample_sheet/models.py
+++ b/cg_lims/EPPs/files/sample_sheet/models.py
@@ -73,29 +73,29 @@ class NovaSeqXRun:
             f"RunName,{self.run_name}\n"
             f"InstrumentType,{self.instrument_type}\n"
             f"InstrumentPlatform,{self.instrument_platform}\n"
-            f"IndexOrientation,{self.index_orientation}\n\n"
+            f"IndexOrientation,{self.index_orientation}\n"
         )
 
     def create_reads_section(self) -> str:
         """Return the [Reads] section of the sample sheet."""
         return (
-            f"{SampleSheetHeader.READS_SECTION}\n"
+            f"\n{SampleSheetHeader.READS_SECTION}\n"
             f"Read1Cycles,{self.read_1_cycles}\n"
             f"Read2Cycles,{self.read_2_cycles}\n"
             f"Index1Cycles,{self.index_1_cycles}\n"
-            f"Index2Cycles,{self.index_2_cycles}\n\n"
+            f"Index2Cycles,{self.index_2_cycles}\n"
         )
 
     def create_sequencing_settings_section(self) -> str:
         """Return the [Sequencing_Settings] section of the sample sheet"""
         return (
-            f"{SampleSheetHeader.SETTINGS_SECTION}\n"
-            f"InputContainerIdentifier,{self.library_tube_id}\n\n"
+            f"\n{SampleSheetHeader.SETTINGS_SECTION}\n"
+            f"InputContainerIdentifier,{self.library_tube_id}\n"
         )
 
     def get_bcl_data_header_row(self) -> str:
         """Return the .csv-header of the BCLConvert_Data content section."""
-        base_header = "Lane,Sample_ID,Index"
+        base_header = f"\nLane,Sample_ID,Index"
         if self.index_2_cycles:
             base_header = base_header + ",Index2"
         if self.override_cycles:


### PR DESCRIPTION
### Added
- The ability to look at the value of the process UDF "DRAGEN Demultiplex", and then decide if a BCL convert section should be added or not.


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


