### PR TITLE
Patch TWIST EPPs to take new UDF "Maximum input amount (ng)" into consideration

### DIFF
--- a/cg_lims/EPPs/udf/calculate/twist_aliquot_amount.py
+++ b/cg_lims/EPPs/udf/calculate/twist_aliquot_amount.py
@@ -7,7 +7,7 @@ from genologics.entities import Artifact
 
 from cg_lims.exceptions import LimsError, MissingUDFsError
 from cg_lims.get.artifacts import get_artifacts
-from cg_lims.get.samples import get_one_sample_from_artifact
+from cg_lims.get.udfs import get_maximum_amount
 
 LOG = logging.getLogger(__name__)
 
@@ -17,15 +17,6 @@ LOG = logging.getLogger(__name__)
 MAXIMUM_SAMPLE_AMOUNT = 250
 
 
-def get_maximum_amount(artifact: Artifact) -> float:
-    """Return the maximum allowed input amount of an artifact."""
-    sample = get_one_sample_from_artifact(artifact=artifact)
-    maximum_amount = sample.udf.get("Maximum input amount (ng)")
-    if maximum_amount:
-        return maximum_amount
-    return MAXIMUM_SAMPLE_AMOUNT
-
-
 def set_amount_needed(artifacts: List[Artifact]):
     """The maximum amount taken into the prep is MAXIMUM_SAMPLE_AMOUNT.
     Any amount below this can be used in the prep if the total amount is limited."""
@@ -33,7 +24,7 @@ def set_amount_needed(artifacts: List[Artifact]):
     missing_udfs = 0
     for artifact in artifacts:
         amount = artifact.udf.get("Amount (ng)")
-        maximum_amount = get_maximum_amount(artifact=artifact)
+        maximum_amount = get_maximum_amount(artifact=artifact, default_amount=MAXIMUM_SAMPLE_AMOUNT)
         if not amount:
             missing_udfs += 1
             continue

--- a/cg_lims/EPPs/udf/calculate/twist_aliquot_amount.py
+++ b/cg_lims/EPPs/udf/calculate/twist_aliquot_amount.py
@@ -7,6 +7,7 @@ from genologics.entities import Artifact
 
 from cg_lims.exceptions import LimsError, MissingUDFsError
 from cg_lims.get.artifacts import get_artifacts
+from cg_lims.get.samples import get_one_sample_from_artifact
 
 LOG = logging.getLogger(__name__)
 
@@ -16,21 +17,31 @@ LOG = logging.getLogger(__name__)
 MAXIMUM_SAMPLE_AMOUNT = 250
 
 
+def get_maximum_amount(artifact: Artifact) -> float:
+    """Return the maximum allowed input amount of an artifact."""
+    sample = get_one_sample_from_artifact(artifact=artifact)
+    maximum_amount = sample.udf.get("Maximum input amount (ng)")
+    if maximum_amount:
+        return maximum_amount
+    return MAXIMUM_SAMPLE_AMOUNT
+
+
 def set_amount_needed(artifacts: List[Artifact]):
     """The maximum amount taken into the prep is MAXIMUM_SAMPLE_AMOUNT.
     Any amount below this can be used in the prep if the total amount is limited."""
 
     missing_udfs = 0
-    for art in artifacts:
-        amount = art.udf.get("Amount (ng)")
+    for artifact in artifacts:
+        amount = artifact.udf.get("Amount (ng)")
+        maximum_amount = get_maximum_amount(artifact=artifact)
         if not amount:
             missing_udfs += 1
             continue
-        if amount >= MAXIMUM_SAMPLE_AMOUNT:
-            art.udf["Amount needed (ng)"] = MAXIMUM_SAMPLE_AMOUNT
+        if amount >= maximum_amount:
+            artifact.udf["Amount needed (ng)"] = maximum_amount
         else:
-            art.udf["Amount needed (ng)"] = amount
-        art.put()
+            artifact.udf["Amount needed (ng)"] = amount
+        artifact.put()
 
     if missing_udfs:
         raise MissingUDFsError(f"Udf missing for {missing_udfs} samples")

--- a/cg_lims/EPPs/udf/calculate/twist_qc_amount.py
+++ b/cg_lims/EPPs/udf/calculate/twist_qc_amount.py
@@ -18,14 +18,12 @@ def get_qc(source: str, conc: float, amount: float) -> str:
     """
 
     qc = "FAILED"
-
     if source == "cell-free DNA" or source == "cfDNA":
-        if amount >= 10 and conc <= 250 and conc >= 0.2:
+        if amount >= 10 and 250 >= conc >= 0.2:
             qc = "PASSED"
     else:
-        if amount >= 250 and conc <= 250 and conc >= 8.33:
+        if amount >= 250 and 250 >= conc >= 8.33:
             qc = "PASSED"
-
     return qc
 
 
@@ -70,11 +68,10 @@ def twist_qc_amount(ctx):
     LOG.info(f"Running {ctx.command_path} with params: {ctx.params}")
 
     process = ctx.obj["process"]
-    lims = ctx.obj["lims"]
 
     try:
         artifacts = get_artifacts(process=process, measurement=True)
-        calculate_amount_and_set_qc(artifacts)
+        calculate_amount_and_set_qc(artifacts=artifacts)
         message = "Amounts have been calculated and qc flags set for all samples."
         LOG.info(message)
         click.echo(message)

--- a/cg_lims/EPPs/udf/calculate/twist_qc_amount.py
+++ b/cg_lims/EPPs/udf/calculate/twist_qc_amount.py
@@ -8,19 +8,11 @@ from genologics.entities import Artifact
 from cg_lims.exceptions import FailingQCError, LimsError, MissingUDFsError
 from cg_lims.get.artifacts import get_artifacts
 from cg_lims.get.samples import get_one_sample_from_artifact
+from cg_lims.get.udfs import get_maximum_amount
 
 LOG = logging.getLogger(__name__)
 
 MAXIMUM_SAMPLE_AMOUNT = 250
-
-
-def get_maximum_amount(artifact: Artifact) -> float:
-    """Return the maximum allowed input amount of an artifact."""
-    sample = get_one_sample_from_artifact(artifact=artifact)
-    maximum_amount = sample.udf.get("Maximum input amount (ng)")
-    if maximum_amount:
-        return maximum_amount
-    return MAXIMUM_SAMPLE_AMOUNT
 
 
 def get_qc(source: str, conc: float, amount: float, max_amount: float) -> str:
@@ -54,7 +46,7 @@ def calculate_amount_and_set_qc(artifacts: List[Artifact]) -> None:
 
         amount = conc * (vol - 3)
         artifact.udf["Amount (ng)"] = amount
-        max_amount = get_maximum_amount(artifact=artifact)
+        max_amount = get_maximum_amount(artifact=artifact, default_amount=MAXIMUM_SAMPLE_AMOUNT)
         qc = get_qc(source=source, conc=conc, amount=amount, max_amount=max_amount)
         if qc == "FAILED":
             qc_fail_count += 1

--- a/cg_lims/get/udfs.py
+++ b/cg_lims/get/udfs.py
@@ -1,7 +1,7 @@
 from datetime import date
 from enum import Enum
 from typing import Optional
-from genologics.entities import Entity
+from genologics.entities import Entity, Artifact
 from genologics.lims import Lims
 
 from cg_lims.exceptions import MissingUDFsError
@@ -50,3 +50,12 @@ def get_q30_threshold(entity: Entity) -> Optional[str]:
         return get_udf(entity, UserDefinedFields.Q30_THRESHOLD.value)
     except MissingUDFsError:
         return None
+
+
+def get_maximum_amount(artifact: Artifact, default_amount: float) -> float:
+    """Return the maximum allowed input amount of an artifact. A default value is returned if no UDF has been set."""
+    sample = artifact.samples[0]
+    maximum_amount = sample.udf.get("Maximum input amount (ng)")
+    if maximum_amount:
+        return maximum_amount
+    return default_amount


### PR DESCRIPTION
### Added
- new functions to fetch the maximum input amount of samples

### Changed
- the threshold used when assessing input amounts


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


