### PR TITLE
Rename and generalise the aliquot volumes calculator EPP

### DIFF
--- a/cg_lims/EPPs/udf/calculate/aliquot_volume.py
+++ b/cg_lims/EPPs/udf/calculate/aliquot_volume.py
@@ -32,12 +32,14 @@ def calculate_volumes(artifacts: List[Artifact], process: Process):
         art.put()
 
     if missing_udfs:
-        raise MissingUDFsError(f"Udf missing for {missing_udfs} samples")
+        raise MissingUDFsError(
+            f"UDFs 'Concentration' and/or 'Amount needed (ng)' missing for {missing_udfs} samples"
+        )
 
 
 @click.command()
 @click.pass_context
-def twist_aliquot_volume(ctx):
+def aliquot_volume(ctx):
     """Calculates amount needed for samples."""
 
     LOG.info(f"Running {ctx.command_path} with params: {ctx.params}")

--- a/cg_lims/EPPs/udf/calculate/base.py
+++ b/cg_lims/EPPs/udf/calculate/base.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import click
+from cg_lims.EPPs.udf.calculate.aliquot_volume import aliquot_volume
 from cg_lims.EPPs.udf.calculate.calculate_amount_ng import calculate_amount_ng
 from cg_lims.EPPs.udf.calculate.calculate_average_size_and_set_qc import (
     calculate_average_size_and_set_qc,
@@ -22,7 +23,6 @@ from cg_lims.EPPs.udf.calculate.novaseq_x_volumes import novaseq_x_volumes
 from cg_lims.EPPs.udf.calculate.pool_normalization import pool_normalization
 from cg_lims.EPPs.udf.calculate.sum_missing_reads_in_pool import missing_reads_in_pool
 from cg_lims.EPPs.udf.calculate.twist_aliquot_amount import twist_aliquot_amount
-from cg_lims.EPPs.udf.calculate.twist_aliquot_volume import twist_aliquot_volume
 from cg_lims.EPPs.udf.calculate.twist_get_volumes_from_buffer import get_volumes_from_buffer
 
 # commands
@@ -39,7 +39,7 @@ def calculate(ctx):
 
 calculate.add_command(twist_pool)
 calculate.add_command(twist_aliquot_amount)
-calculate.add_command(twist_aliquot_volume)
+calculate.add_command(aliquot_volume)
 calculate.add_command(twist_qc_amount)
 calculate.add_command(get_volumes_from_buffer)
 calculate.add_command(get_missing_reads)

--- a/tests/EPPs/udf/calculate/test_aliquot_volume.py
+++ b/tests/EPPs/udf/calculate/test_aliquot_volume.py
@@ -1,0 +1,97 @@
+import pytest
+from cg_lims.EPPs.udf.calculate.aliquot_volume import calculate_volumes
+from cg_lims.exceptions import MissingUDFsError
+from genologics.entities import Artifact, Process
+from genologics.lims import Lims
+from tests.conftest import server
+
+
+@pytest.mark.parametrize(
+    "total_volume,concentration,amount,sample_vol,water_vol",
+    [
+        (50, 10, 200, 20, 30),
+        (30, 10, 200, 20, 10),
+        (50, 2, 100, 50, 0),
+        (30, 2, 10, 5, 25),
+    ],
+)
+def test_calculate_volumes(
+    lims: Lims,
+    total_volume: float,
+    concentration: float,
+    amount: float,
+    sample_vol: float,
+    water_vol: float,
+):
+    # GIVEN:
+    # - A process with the UDF 'Total Volume (ul)' <total_volume>
+    # - An artifact with values for the UDFs 'Concentration' <concentration> and 'Amount needed (ul)' <amount>
+    server("flat_tests")
+
+    process = Process(lims=lims, id="24-196211")
+    process.udf["Total Volume (ul)"] = total_volume
+    process.put()
+
+    artifact_1 = Artifact(lims=lims, id="1")
+    artifact_1.udf["Concentration"] = concentration
+    artifact_1.udf["Amount needed (ng)"] = amount
+    artifact_1.put()
+
+    # WHEN calculating the aliquot sample and water volumes
+    calculate_volumes(artifacts=[artifact_1], process=process)
+
+    # THEN the correct values are calculated for the artifact UDFs 'Volume H2O (ul)' and 'Sample Volume (ul)'
+    assert artifact_1.udf["Sample Volume (ul)"] == sample_vol
+    assert artifact_1.udf["Volume H2O (ul)"] == water_vol
+
+
+@pytest.mark.parametrize(
+    "udf_name",
+    ["Concentration", "Amount needed (ng)"],
+)
+def test_calculate_volumes_missing_artifact_udf(lims: Lims, udf_name: str):
+    # GIVEN:
+    # - A process with the UDF 'Total Volume (ul)' set
+    # - An artifact (artifact_1) with values missing for either 'Concentration' or 'Amount needed (ul)'
+    # - Another artifact (artifact_2) with all necessary values set
+
+    server("flat_tests")
+
+    process = Process(lims=lims, id="24-196211")
+    process.udf["Total Volume (ul)"] = 50
+    process.put()
+
+    artifact_1 = Artifact(lims=lims, id="1")
+    artifact_1.udf[udf_name] = 100
+    artifact_1.put()
+
+    artifact_2 = Artifact(lims=lims, id="2")
+    artifact_2.udf["Concentration"] = 10
+    artifact_2.udf["Amount needed (ng)"] = 200
+    artifact_2.put()
+
+    # WHEN calculating the aliquot sample and water volumes
+    # THEN MissingUDFsError is being raised, while also correctly setting the values for artifact_2
+    with pytest.raises(MissingUDFsError):
+        calculate_volumes(artifacts=[artifact_1, artifact_2], process=process)
+    assert artifact_2.udf["Sample Volume (ul)"] == 20
+    assert artifact_2.udf["Volume H2O (ul)"] == 30
+
+
+def test_calculate_volumes_missing_process_udf(lims: Lims):
+    # GIVEN:
+    # - A process without the UDF 'Total Volume (ul)' set
+    # - An artifact with values for the UDFs 'Concentration' and 'Amount needed (ul)' set
+    server("flat_tests")
+
+    process = Process(lims=lims, id="24-196211")
+
+    artifact_1 = Artifact(lims=lims, id="1")
+    artifact_1.udf["Concentration"] = 10
+    artifact_1.udf["Amount needed (ng)"] = 100
+    artifact_1.put()
+
+    # WHEN calculating the aliquot sample and water volumes
+    # THEN MissingUDFsError is being raised
+    with pytest.raises(MissingUDFsError):
+        calculate_volumes(artifacts=[artifact_1], process=process)


### PR DESCRIPTION
### Added
- Pytests for the aliquot_volume.py module

### Changed
- Renamed the Python module from `twist_aliquot_volume.py` -> `aliquot_volume.py`
- Renamed the Click subcommand from "twist-aliquot-volume" to "aliquot-volume" (changes needed for the existing automations!)

### Fixed
- Spelling and imports

**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [x] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


