### PR TITLE
Add new EPP for automatically setting ONT sequencing settings

### DIFF
--- a/cg_lims/EPPs/udf/set/base.py
+++ b/cg_lims/EPPs/udf/set/base.py
@@ -2,6 +2,7 @@ import click
 from cg_lims.EPPs.udf.set.replace_flow_cell_output_path import replace_flow_cell_output_path
 from cg_lims.EPPs.udf.set.set_barcode import assign_barcode
 from cg_lims.EPPs.udf.set.set_method import method_document
+from cg_lims.EPPs.udf.set.set_ont_sequencing_settings import set_ont_sequencing_settings
 from cg_lims.EPPs.udf.set.set_sample_date import set_sample_date
 from cg_lims.EPPs.udf.set.set_samples_reads_missing import set_reads_missing_on_new_samples
 from cg_lims.EPPs.udf.set.set_sequencing_settings import set_sequencing_settings
@@ -18,5 +19,6 @@ set.add_command(set_reads_missing_on_new_samples)
 set.add_command(set_sample_date)
 set.add_command(method_document)
 set.add_command(assign_barcode)
+set.add_command(set_ont_sequencing_settings)
 set.add_command(set_sequencing_settings)
 set.add_command(replace_flow_cell_output_path)

--- a/cg_lims/EPPs/udf/set/set_ont_sequencing_settings.py
+++ b/cg_lims/EPPs/udf/set/set_ont_sequencing_settings.py
@@ -1,0 +1,44 @@
+import logging
+import sys
+from datetime import date
+
+import click
+from cg_lims.exceptions import LimsError
+from cg_lims.get.artifacts import get_artifacts
+from genologics.entities import Process
+
+LOG = logging.getLogger(__name__)
+
+
+def get_experiment_name(process: Process) -> str:
+    """Create and return an experiment name from today's date and the step ID."""
+    return f"{date.today().strftime('%y%m%d')}_{process.id}"
+
+
+def set_experiment_name(process: Process) -> None:
+    """Set the experiment name to both process and artifact UDFs."""
+    experiment_name: str = get_experiment_name(process=process)
+    process.udf["Experiment Name"] = experiment_name
+    process.put()
+    for artifact in get_artifacts(process=process):
+        artifact.udf["ONT Experiment Name"] = experiment_name
+        artifact.put()
+
+
+@click.command()
+@click.pass_context
+def set_ont_sequencing_settings(ctx):
+    """Sets the settings required for sequencing of ONT flow cells."""
+
+    LOG.info(f"Running {ctx.command_path} with params: {ctx.params}")
+
+    process: Process = ctx.obj["process"]
+
+    try:
+        set_experiment_name(process=process)
+        message: str = "Sequencing settings have been successfully set."
+        LOG.info(message)
+        click.echo(message)
+    except LimsError as e:
+        LOG.error(e.message)
+        sys.exit(e.message)


### PR DESCRIPTION
### Added
- New EPP for automatically setting ONT sequencing settings


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


