### PR TITLE
Add new process udf for NA24385 prep control to arnold

### DIFF
--- a/cg_lims/EPPs/files/sample_sheet/create_sample_sheet.py
+++ b/cg_lims/EPPs/files/sample_sheet/create_sample_sheet.py
@@ -152,7 +152,9 @@ def calculate_index_hamming_distance(
             return string_hamming_distance(
                 index_1=index_1.sequence[-len(index_2.sequence) :], index_2=index_2.sequence
             )
-    message: str = f"Non-supported index type identified for indexes {index_1.sequence} and {index_2.sequence}: '{index_1.type}'."
+    message: str = (
+        f"Non-supported index type identified for indexes {index_1.sequence} and {index_2.sequence}: '{index_1.type}'."
+    )
     LOG.error(message)
     raise InvalidValueError(message)
 

--- a/cg_lims/models/arnold/prep/twist/aliquot_samples_for_enzymatic_fragmentation_twist.py
+++ b/cg_lims/models/arnold/prep/twist/aliquot_samples_for_enzymatic_fragmentation_twist.py
@@ -8,6 +8,7 @@ from pydantic.v1 import BaseModel, Field
 
 class ProcessUDFs(BaseModel):
     performance_NA24143: Optional[str] = Field(None, alias="Batch no Prep Performance NA24143")
+    performance_NA24385: Optional[str] = Field(None, alias="Batch no Prep Performance NA24385")
     GMCKsolid_HD827: Optional[str] = Field(None, alias="Batch no GMCKsolid-HD827")
     GMSlymphoid_HD829: Optional[str] = Field(None, alias="Batch no GMSlymphoid-HD829")
     GMSmyeloid_HD829: Optional[str] = Field(None, alias="Batch no GMSmyeloid-HD829")

--- a/cg_lims/options.py
+++ b/cg_lims/options.py
@@ -394,7 +394,7 @@ def concentration_threshold(help: str = "Threshold for concentrations.") -> clic
 def size_bp(help: str = "Fragment size in base pairs.") -> click.option:
     return click.option("--size-bp", required=True, help=help)
 
-  
+
 def root_path(
     help: str = "Root path to be used by the script to find files.",
 ) -> click.option:
@@ -445,4 +445,3 @@ def well_udf(help: str = "UDF name for artifact well.") -> click.option:
 
 def container_name_udf(help: str = "UDF name for container name.") -> click.option:
     return click.option("--container-name-udf", required=False, default=None, help=help)
-


### PR DESCRIPTION
### Added
- a new Arnold process UDF for the TWIST workflow, "Batch no Prep Performance NA24385" in [aliquot_samples_for_enzymatic_fragmentation_twist.py](https://github.com/Clinical-Genomics/cg_lims/blob/master/cg_lims/models/arnold/prep/twist/aliquot_samples_for_enzymatic_fragmentation_twist.py)


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


