### PR TITLE
change constants for minimum lane volume

### DIFF
--- a/cg_lims/EPPs/udf/calculate/constants.py
+++ b/cg_lims/EPPs/udf/calculate/constants.py
@@ -20,7 +20,7 @@ class FlowCellSize(IntEnum):
 class FlowCellLaneVolumes10B(FloatEnum):
     """The recommended volume of reagents per 10B flow cell lane. All values are in ul."""
 
-    POOL_VOLUME: float = 34
+    POOL_VOLUME: float = 35
     PHIX_VOLUME: float = 1
     NAOH_VOLUME: float = 8.5
     BUFFER_VOLUME: float = 127.5
@@ -29,7 +29,7 @@ class FlowCellLaneVolumes10B(FloatEnum):
 class FlowCellLaneVolumes15B(FloatEnum):
     """The recommended volume of reagents per 1.5B flow cell lane. All values are in ul."""
 
-    POOL_VOLUME: float = 34
+    POOL_VOLUME: float = 35
     PHIX_VOLUME: float = 1
     NAOH_VOLUME: float = 8.5
     BUFFER_VOLUME: float = 127.5
@@ -38,7 +38,7 @@ class FlowCellLaneVolumes15B(FloatEnum):
 class FlowCellLaneVolumes25B(FloatEnum):
     """The recommended volume of reagents per 25B flow cell lane. All values are in ul."""
 
-    POOL_VOLUME: float = 56
+    POOL_VOLUME: float = 57
     PHIX_VOLUME: float = 1.6
     NAOH_VOLUME: float = 14
     BUFFER_VOLUME: float = 210


### PR DESCRIPTION
### Added

### Changed
- Constants for minimum volume per lane for flowcells 1.5, 10 and 25B with +1ul.

### Fixed


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


