### PR TITLE
Count NTC reads in sequencing QC check

### DIFF
--- a/cg_lims/EPPs/qc/sequencing_quality_control.py
+++ b/cg_lims/EPPs/qc/sequencing_quality_control.py
@@ -26,7 +26,7 @@ def sequencing_quality_control(ctx):
         cg_api_client=status_db_api,
     )
 
-    quality_summary: str = quality_checker.validate_sequencing_quality()
+    quality_summary: str = quality_checker.validate_sequencing_quality(lims=lims)
     brief_summary: str = quality_checker.get_brief_summary()
 
     if quality_checker.samples_failed_quality_control():

--- a/cg_lims/get/samples.py
+++ b/cg_lims/get/samples.py
@@ -1,5 +1,6 @@
 import logging
 from typing import List
+from xml.etree.ElementTree import ParseError
 
 from cg_lims.exceptions import MissingSampleError
 from genologics.entities import Artifact, Process, Sample
@@ -41,7 +42,12 @@ def get_one_sample_from_artifact(artifact: Artifact) -> Sample:
 
 def is_negative_control(sample: Sample) -> bool:
     """Check if a given sample is a negative control."""
-    control: str = sample.udf.get("Control")
-    if control == "negative":
-        return True
-    return False
+    try:
+        control: str = sample.udf.get("Control")
+        if control == "negative":
+            return True
+        return False
+    except ParseError:
+        error_message = f"Sample {sample} can't be found in the database."
+        LOG.error(error_message)
+        raise MissingSampleError(error_message)

--- a/cg_lims/get/samples.py
+++ b/cg_lims/get/samples.py
@@ -37,3 +37,11 @@ def get_one_sample_from_artifact(artifact: Artifact) -> Sample:
         raise MissingSampleError(message=more_than_one_message)
 
     return samples[0]
+
+
+def is_negative_control(sample: Sample) -> bool:
+    """Check if a given sample is a negative control."""
+    control: str = sample.udf.get("Control")
+    if control == "negative":
+        return True
+    return False

--- a/tests/EPPs/qc/test_sequencing_quality_checker.py
+++ b/tests/EPPs/qc/test_sequencing_quality_checker.py
@@ -11,7 +11,7 @@ def test_quality_control_of_flow_cell_with_all_passing(
     mocker,
     lims: Lims,
 ):
-    # GIVEN a flow cell where all samples passes the quality control
+    # GIVEN a flow cell with one negative control where all samples passes the quality control
     mocker.patch("requests.get", return_value=novaseq_passing_metrics_response)
 
     # WHEN validating the sequencing quality
@@ -29,14 +29,14 @@ def test_all_samples_fail_q30(
     mocker,
     lims: Lims,
 ):
-    # GIVEN a flow cell where all samples fail the quality control on Q30
+    # GIVEN a flow cell with one negative control where all samples fail the quality control on Q30
     mocker.patch("requests.get", return_value=novaseq_q30_fail_response)
 
     # WHEN validating the sequencing quality
     sequencing_quality_checker.validate_sequencing_quality(lims=lims)
 
     # THEN all samples in all lanes should fail the quality control
-    expected_fails: int = novaseq_lanes * len(novaseq_sample_ids)
+    expected_fails: int = novaseq_lanes * (len(novaseq_sample_ids) - 1)
     assert sequencing_quality_checker.failed_qc_count == expected_fails
 
 
@@ -48,14 +48,14 @@ def test_all_samples_have_too_few_reads(
     mocker,
     lims: Lims,
 ):
-    # GIVEN a flow cell where all samples in all lanes have too few reads
+    # GIVEN a flow cell with one negative control where all samples in all lanes have too few reads
     mocker.patch("requests.get", return_value=novaseq_reads_fail_response)
 
     # WHEN validating the sequencing quality
     sequencing_quality_checker.validate_sequencing_quality(lims=lims)
 
     # THEN all samples in all lanes should fail the quality control
-    expected_fails: int = novaseq_lanes * len(novaseq_sample_ids)
+    expected_fails: int = novaseq_lanes * (len(novaseq_sample_ids) - 1)
     assert sequencing_quality_checker.failed_qc_count == expected_fails
 
 
@@ -65,7 +65,7 @@ def test_some_samples_fail_quality_control(
     mocker,
     lims: Lims,
 ):
-    # GIVEN a flow cell where some samples fail the quality control
+    # GIVEN a flow cell with one negative control where some samples (not the NTC) fail the quality control
     mocker.patch("requests.get", return_value=novaseq_two_failing_metrics_response)
 
     # WHEN validating the sequencing quality

--- a/tests/EPPs/qc/test_sequencing_quality_checker.py
+++ b/tests/EPPs/qc/test_sequencing_quality_checker.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from cg_lims.EPPs.qc.sequencing_quality_checker import SequencingQualityChecker
+from genologics.lims import Lims
 from mock import Mock
 
 
@@ -8,12 +9,13 @@ def test_quality_control_of_flow_cell_with_all_passing(
     sequencing_quality_checker: SequencingQualityChecker,
     novaseq_passing_metrics_response: Mock,
     mocker,
+    lims: Lims,
 ):
     # GIVEN a flow cell where all samples passes the quality control
     mocker.patch("requests.get", return_value=novaseq_passing_metrics_response)
 
     # WHEN validating the sequencing quality
-    sequencing_quality_checker.validate_sequencing_quality()
+    sequencing_quality_checker.validate_sequencing_quality(lims=lims)
 
     # THEN no samples should fail the quality control
     assert sequencing_quality_checker.failed_qc_count == 0
@@ -25,12 +27,13 @@ def test_all_samples_fail_q30(
     novaseq_sample_ids: List[str],
     novaseq_lanes,
     mocker,
+    lims: Lims,
 ):
     # GIVEN a flow cell where all samples fail the quality control on Q30
     mocker.patch("requests.get", return_value=novaseq_q30_fail_response)
 
     # WHEN validating the sequencing quality
-    sequencing_quality_checker.validate_sequencing_quality()
+    sequencing_quality_checker.validate_sequencing_quality(lims=lims)
 
     # THEN all samples in all lanes should fail the quality control
     expected_fails: int = novaseq_lanes * len(novaseq_sample_ids)
@@ -43,12 +46,13 @@ def test_all_samples_have_too_few_reads(
     novaseq_sample_ids: List[str],
     novaseq_lanes: int,
     mocker,
+    lims: Lims,
 ):
     # GIVEN a flow cell where all samples in all lanes have too few reads
     mocker.patch("requests.get", return_value=novaseq_reads_fail_response)
 
     # WHEN validating the sequencing quality
-    sequencing_quality_checker.validate_sequencing_quality()
+    sequencing_quality_checker.validate_sequencing_quality(lims=lims)
 
     # THEN all samples in all lanes should fail the quality control
     expected_fails: int = novaseq_lanes * len(novaseq_sample_ids)
@@ -59,12 +63,13 @@ def test_some_samples_fail_quality_control(
     sequencing_quality_checker: SequencingQualityChecker,
     novaseq_two_failing_metrics_response: Mock,
     mocker,
+    lims: Lims,
 ):
     # GIVEN a flow cell where some samples fail the quality control
     mocker.patch("requests.get", return_value=novaseq_two_failing_metrics_response)
 
     # WHEN validating the sequencing quality
-    sequencing_quality_checker.validate_sequencing_quality()
+    sequencing_quality_checker.validate_sequencing_quality(lims=lims)
 
     # THEN some samples in all lanes should fail the quality control
     assert sequencing_quality_checker.failed_qc_count == 2
@@ -76,12 +81,13 @@ def test_metrics_missing_for_samples_in_lane(
     missing_sample_id: str,
     missing_lane: int,
     mocker,
+    lims: Lims,
 ):
     # GIVEN metrics missing data for a sample in lims
     mocker.patch("requests.get", return_value=novaseq_missing_metrics_for_sample_in_lane_response)
 
     # WHEN validating the sequencing quality
-    summary: str = sequencing_quality_checker.validate_sequencing_quality()
+    summary: str = sequencing_quality_checker.validate_sequencing_quality(lims=lims)
 
     # THEN the sample with missing metrics should fail qc
     assert sequencing_quality_checker.failed_qc_count == 1
@@ -96,12 +102,13 @@ def test_sample_missing_in_lims(
     novaseq_metrics_with_extra_sample_response: Mock,
     sample_id_missing_in_lims: str,
     mocker,
+    lims: Lims,
 ):
     # GIVEN metrics with a sample not in lims
     mocker.patch("requests.get", return_value=novaseq_metrics_with_extra_sample_response)
 
     # WHEN validating the sequencing quality
-    summary: str = sequencing_quality_checker.validate_sequencing_quality()
+    summary: str = sequencing_quality_checker.validate_sequencing_quality(lims=lims)
 
     # THEN all samples pass the quality control
     assert sequencing_quality_checker.failed_qc_count == 0

--- a/tests/fixtures/novaseq_standard/samples/ACC9628A2.xml
+++ b/tests/fixtures/novaseq_standard/samples/ACC9628A2.xml
@@ -31,4 +31,5 @@
     <udf:field type="Numeric" name="Reads missing (M)">0</udf:field>
     <udf:field type="String" name="Index type">NEXTflex® v2 UDI Barcodes 1 - 96</udf:field>
     <udf:field type="String" name="Index number">13</udf:field>
+    <udf:field type="String" name="Control">negative</udf:field>
 </smp:sample>


### PR DESCRIPTION
### Changed
- NTCs now won't fail when having either reads or Q30 values below the given thresholds. Connected to https://github.com/Clinical-Genomics/cg_lims/issues/524


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


