### PR TITLE
New Elution Buffer fields in Arnold twist

### DIFF
--- a/cg_lims/models/arnold/prep/twist/aliquot_samples_for_enzymatic_fragmentation_twist.py
+++ b/cg_lims/models/arnold/prep/twist/aliquot_samples_for_enzymatic_fragmentation_twist.py
@@ -23,6 +23,7 @@ class ProcessUDFs(BaseModel):
     lot_nr_h2o_aliquot_samples_fragmentation: Optional[str] = Field(
         None, alias="Nuclease free water"
     )
+    lot_nr_elution_buffer_aliquot_samples_fragmentation: Optional[str] = Field(None, alias="Lot no: Elution Buffer")
 
 
 class ArtifactUDFs(BaseModel):

--- a/cg_lims/models/arnold/prep/twist/bead_purification_twist.py
+++ b/cg_lims/models/arnold/prep/twist/bead_purification_twist.py
@@ -14,6 +14,7 @@ class ArtifactUDFs(BaseModel):
 class ProcessUDFs(BaseModel):
     lot_nr_etoh_bead_purification_post_hyb: Optional[str] = Field(None, alias="Ethanol")
     lot_nr_h2o_bead_purification_post_hyb: Optional[str] = Field(None, alias="Nuclease free water")
+    lot_nr_elution_buffer_bead_purification_post_hyb: Optional[str] = Field(None, alias="Lot no: Elution Buffer")
     bead_purification_post_hyb_method: Optional[str] = Field(None, alias="Method document")
     binding_and_purification_beads: Optional[str] = Field(
         None, alias="Twist Binding and Purification beads"

--- a/cg_lims/models/arnold/prep/twist/buffer_exchange.py
+++ b/cg_lims/models/arnold/prep/twist/buffer_exchange.py
@@ -10,8 +10,14 @@ class ArtifactUDFs(BaseModel):
     concentration: Optional[float] = Field(None, alias="Concentration")
 
 
+class ProcessUDFs(BaseModel):
+    lot_nr_elution_buffer_bex: Optional[str] = Field(None, alias="Lot no: Elution Buffer")
+    )
+
+
 class ArnoldStep(BaseStep):
     artifact_udfs: ArtifactUDFs
+    process_udfs: ProcessUDFs
 
     class Config:
         allow_population_by_field_name = True
@@ -31,6 +37,7 @@ def get_buffer_exchange_twist(lims: Lims, sample_id: str, prep_id: str) -> Optio
     return ArnoldStep(
         **analyte.base_fields(),
         artifact_udfs=ArtifactUDFs(**analyte.artifact_udfs()),
+        process_udfs=ProcessUDFs(**analyte.process_udfs()),
         sample_id=sample_id,
         prep_id=prep_id,
         step_type="buffer_exchange",

--- a/cg_lims/models/arnold/prep/twist/buffer_exchange.py
+++ b/cg_lims/models/arnold/prep/twist/buffer_exchange.py
@@ -12,7 +12,6 @@ class ArtifactUDFs(BaseModel):
 
 class ProcessUDFs(BaseModel):
     lot_nr_elution_buffer_bex: Optional[str] = Field(None, alias="Lot no: Elution Buffer")
-    )
 
 
 class ArnoldStep(BaseStep):


### PR DESCRIPTION
Part of issue #568 

### Added
- New process UDFs: "Lot no: Elution Buffer" in buffer_exchange.py, aliquot_samples_for_enzymatic_fragmentation_trist.py and bead_purification_twist.py

### Changed

### Fixed


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


