### PR TITLE
Add sample-artifact flag to the sample rerun EPP

### DIFF
--- a/cg_lims/EPPs/files/femtopulse_csv.py
+++ b/cg_lims/EPPs/files/femtopulse_csv.py
@@ -37,8 +37,9 @@ def get_data_and_write(artifacts: List[Artifact], num_of_ladders: int, file: str
     index, sample position and sample name, blank or ladder."""
 
     # Get well positions and sample names and sort by well position
-    samples_and_positions: List[Tuple[str,str]] = [(get_artifact_well(artifact), get_sample_artifact_name(artifact))
-        for artifact in artifacts]
+    samples_and_positions: List[Tuple[str, str]] = [
+        (get_artifact_well(artifact), get_sample_artifact_name(artifact)) for artifact in artifacts
+    ]
     samples_and_positions.sort(key=lambda x: (x[0][0], int(x[0][1:])))
 
     # Check that no sample is in position 12, where the ladders should be.
@@ -87,6 +88,7 @@ def get_data_and_write(artifacts: List[Artifact], num_of_ladders: int, file: str
             f"Warning: The number of populated sample rows ({len(rows_needed)}) "
             f"exceed the number of ladders ({num_of_ladders})."
         )
+
 
 @click.command()
 @options.file_placeholder()

--- a/cg_lims/EPPs/udf/calculate/revio_abc_volumes.py
+++ b/cg_lims/EPPs/udf/calculate/revio_abc_volumes.py
@@ -3,11 +3,10 @@ import sys
 from typing import List, Optional
 
 import click
-from genologics.entities import Artifact, Process
-
 from cg_lims import options
 from cg_lims.exceptions import LimsError, MissingValueError
 from cg_lims.get.artifacts import get_artifacts
+from genologics.entities import Artifact, Process
 
 LOG = logging.getLogger(__name__)
 
@@ -90,12 +89,10 @@ def set_total_ABC_volumes(
         total_sample_volume=total_sample_volume,
         reagent_ratio=annealing_reagent_ratio,
     )
-    process.udf["Total Polymerase Dilution Mix Volume (ul)"] = (
-        calculate_total_ABC_volumes(
-            factor=factor,
-            total_sample_volume=total_sample_volume,
-            reagent_ratio=polymerase_dilution_mix_ratio,
-        )
+    process.udf["Total Polymerase Dilution Mix Volume (ul)"] = calculate_total_ABC_volumes(
+        factor=factor,
+        total_sample_volume=total_sample_volume,
+        reagent_ratio=polymerase_dilution_mix_ratio,
     )
     process.udf["Polymerase Buffer Volume (ul)"] = calculate_total_ABC_volumes(
         factor=factor,
@@ -144,9 +141,7 @@ def revio_abc_volumes(
                 raise MissingValueError(error_message)
             elif preset_volume:
                 preset_volume: float = float(preset_volume)
-            sample_volume: float = get_artifact_volume(
-                artifact=artifact, volume_udf=volume_udf
-            )
+            sample_volume: float = get_artifact_volume(artifact=artifact, volume_udf=volume_udf)
             annealing_mix_volume: float = sample_volume
             polymerase_dilution_volume: float = calculate_per_sample_mix_volumes(
                 volume_udf=sample_volume,
@@ -176,9 +171,7 @@ def revio_abc_volumes(
             polymerase_dilution_mix_ratio=polymerase_dilution_mix_ratio,
             sequencing_polymerase_ratio=sequencing_polymerase_ratio,
         )
-        message: str = (
-            "ABC volumes have been calculated for all artifacts and process UDFs!"
-        )
+        message: str = "ABC volumes have been calculated for all artifacts and process UDFs!"
         LOG.info(message)
         click.echo(message)
     except LimsError as e:


### PR DESCRIPTION
### Added
- New flag for queueing sample artifacts instead of process-generated ones

### Changed
- Some minor refactoring 


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


