### PR TITLE
Patch default Revio run names

### DIFF
--- a/cg_lims/EPPs/udf/set/set_revio_sequencing_settings.py
+++ b/cg_lims/EPPs/udf/set/set_revio_sequencing_settings.py
@@ -12,14 +12,14 @@ from genologics.entities import Artifact, Container, Process
 LOG = logging.getLogger(__name__)
 
 
-def get_run_name(process: Process) -> str:
+def get_run_name() -> str:
     """Create and return a run name from today's date and the step ID."""
-    return f"{date.today().strftime('%y%m%d')}_{process.id}"
+    return f"Run{date.today().strftime('%y%m%d')}"
 
 
 def set_run_name(process: Process) -> None:
     """Set the run name to both process and artifact UDFs."""
-    run_name: str = get_run_name(process=process)
+    run_name: str = get_run_name()
     process.udf["Run Name"] = run_name
     process.put()
 


### PR DESCRIPTION
### Changed
- Modified the default Revio run name generated in the EPP **cg_lims/EPPs/udf/set/set_revio_sequencing_settings.py**
    - New format: RunYYMMDD 

**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


