### PR TITLE
Add SMRT Cell HiFi yield to run metrics parsing

### DIFF
--- a/cg_lims/EPPs/udf/set/smrt_cell_metrics.py
+++ b/cg_lims/EPPs/udf/set/smrt_cell_metrics.py
@@ -77,6 +77,7 @@ def set_smrt_cell_metrics(
         artifact.udf["P1 %"] = metric.p1_percent
         artifact.udf["P2 %"] = metric.p2_percent
         artifact.udf["% reads passing Q30"] = metric.percent_reads_passing_q30
+        artifact.udf["SMRT Cell HiFi Yield (Gb)"] = metric.hifi_yield / 10**9
         artifact.put()
 
 


### PR DESCRIPTION
### Added
- New metric parsed and set in LIMS for SMRT Cell HiFi yield


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


