### PR TITLE
Revert placement map decimals

### DIFF
--- a/cg_lims/EPPs/files/placement_map/make_96well_placement_map.py
+++ b/cg_lims/EPPs/files/placement_map/make_96well_placement_map.py
@@ -100,7 +100,7 @@ def more_sample_info(artifact: Artifact, udfs: List[str]) -> str:
         value = artifact.udf.get(udf)
         if value is not None:
             if isinstance(value, float):
-                value = round(value, 3)
+                value = round(value, 2)
             html.append(f"{udf} : {value}<br>")
     return "".join(html)
 


### PR DESCRIPTION
### Fixed
- Reverted back to 2 decimals in the placement map, from the change introduced in https://github.com/Clinical-Genomics/cg_lims/pull/629

**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


