### PR TITLE
Remove requirement for more than one sample in a pool

### DIFF
--- a/cg_lims/EPPs/udf/calculate/sum_missing_reads_in_pool.py
+++ b/cg_lims/EPPs/udf/calculate/sum_missing_reads_in_pool.py
@@ -17,8 +17,6 @@ def sum_reads_in_pool(artifacts: list) -> Tuple[int, int]:
     passed_arts = 0
 
     for artifact in artifacts:
-        if len(artifact.samples) == 1:
-            continue
 
         missing_reads_pool = []
         for sample in artifact.samples:


### PR DESCRIPTION
### Added

### Changed
Removed a line of script which enforced a pool to have more than one sample, this allows the calculation of reads missing to be performed on pools containing one sample or more (instead of only working when a pool contains several samples).

Closes https://github.com/Clinical-Genomics/cg_lims/issues/513

### Fixed


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


